### PR TITLE
maint: june 1 windows server 2022 release. fix nvm

### DIFF
--- a/roles/windows-executor/defaults/main/install_buildagent_prereq_defaults.yml
+++ b/roles/windows-executor/defaults/main/install_buildagent_prereq_defaults.yml
@@ -1,5 +1,5 @@
-git_version: 2.35.0
-gitlfs_version: 3.0.2
+git_version: 2.36.0
+gitlfs_version: 3.2.0
 7zip_version: 21.7
 gzip_version: 1.3.12
-sysinternals_version: 2022.2.16
+sysinternals_version: 2022.5.11

--- a/roles/windows-executor/defaults/main/install_cloud_tools_defaults.yml
+++ b/roles/windows-executor/defaults/main/install_cloud_tools_defaults.yml
@@ -1,5 +1,5 @@
-awscli_version: 2.4.13
-azurecli_version: 2.32.0
+awscli_version: 2.7.4
+azurecli_version: 2.37.0
 webpi_version: 5.1
 servicefabric_version: 8.2.1363
 servicefabricsdk_version: 5.2.1363

--- a/roles/windows-executor/defaults/main/install_dev_tools_defaults.yml
+++ b/roles/windows-executor/defaults/main/install_dev_tools_defaults.yml
@@ -1,13 +1,14 @@
-nunit_console_runner_version: 3.14.0
+nunit_console_runner_version: 3.15.0
 nano_version: 2.5.3
-vim_version: 8.2.4219
+vim_version: 8.2.5048
 jq_version: 1.6
-golang_version: 1.17.6
-openjdk_version: 17.0.1
-miniconda3_version: 4.10.3
-python_2_version: 2.7.11
-python_3_version: 3.10.2
-nodejs_version: 17.4.0
-ruby_version: 3.1.0.1
-docker_version: 20.10.14
+golang_version: 1.18.2
+openjdk_version: 18.0.1.1
+miniconda3_version: 4.12.0
+python_2_version: 2.7.18
+python_3_version: 3.10.4
+nodejs_version: 17.9.0
+ruby_version: 3.1.2.1
+docker_version: 20.10.16
 nvm_version: 1.1.9
+nodejs_dir: 'C:\Program Files\nodejs'

--- a/roles/windows-executor/defaults/main/install_microsoft_tools_defaults.yml
+++ b/roles/windows-executor/defaults/main/install_microsoft_tools_defaults.yml
@@ -1,6 +1,6 @@
-dotnet_sdk_version: 6.0.101
+dotnet_sdk_version: 6.0.300
 sqlserver_devedition_version: 15.0.2000.20210324
-visualstudio_community_edition_version: 117.0.5.0
-visualstudio_buildtools_version: 117.0.5.0
-nuget_cli_version: 6.1.0
+visualstudio_community_edition_version: 117.2.2.0
+visualstudio_buildtools_version: 117.2.2.0
+nuget_cli_version: 6.2.0
 winappdriver_version: 1.2.1

--- a/roles/windows-executor/tasks/install_dev_tools.yml
+++ b/roles/windows-executor/tasks/install_dev_tools.yml
@@ -82,6 +82,11 @@
     state: '{{ package_state }}'
     version: '{{ nvm_version }}'
 
+- name: Remove nodejs directory due to nvm issues 
+  ansible.windows.win_file:
+    path: '{{ nodejs_dir }}'
+    state: absent
+
 - name: Install docker
   ansible.windows.win_powershell:
     script: |


### PR DESCRIPTION
OS updates as well as

updated the following packages:

- git
- gitlfs
- sysinternals
- awscli
- azurecli
- nunit 
- vim
- golang
- openjdk
- miniconda3
- python2
- python3
- nodejs
- ruby
- docker-engine
- nvm
- .net sdk
- visual studio community edition
- nuget cli

fix:
remove nodejs directory due to conflict with nvm:
https://discuss.circleci.com/t/march-2022-beta-support-for-new-operating-system-for-windows-executors-windows-server-2022/43198/36
