### PR TITLE
Windows july edge uac fix

### DIFF
--- a/roles/windows-executor/files/disable_default_winservices.ps1
+++ b/roles/windows-executor/files/disable_default_winservices.ps1
@@ -28,7 +28,23 @@
     }
 
     function Disable-UserAccessControl {
+        Write-Host "Diabling User Access Control (UAC)"
+
         Set-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" -Name "ConsentPromptBehaviorAdmin" -Value 00000000 -Force
+
+        Set-ItemProperty -Path REGISTRY::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -Name ConsentPromptBehaviorAdmin -Value 0
+        $token_path = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System"
+        $token_prop_name = "LocalAccountTokenFilterPolicy"
+        $token_key = Get-Item -Path $token_path
+        $token_value = $token_key.GetValue($token_prop_name, $null)
+
+        if ($token_value -ne 1) {
+            Write-Host "Setting LocalAccountTokenFilterPolicy to 1"
+            if ($null -ne $token_value) {
+                Remove-ItemProperty -Path $token_path -Name $token_prop_name
+            }
+            New-ItemProperty -Path $token_path -Name $token_prop_name -Value 1 -PropertyType DWORD > $null
+        } 
         Write-Host "User Access Control (UAC) has been disabled."
     }
     

--- a/roles/windows-executor/files/disable_default_winservices.ps1
+++ b/roles/windows-executor/files/disable_default_winservices.ps1
@@ -30,8 +30,6 @@
     function Disable-UserAccessControl {
         Write-Host "Diabling User Access Control (UAC)"
 
-        Set-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" -Name "ConsentPromptBehaviorAdmin" -Value 00000000 -Force
-
         Set-ItemProperty -Path REGISTRY::HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System -Name ConsentPromptBehaviorAdmin -Value 0
         $token_path = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System"
         $token_prop_name = "LocalAccountTokenFilterPolicy"


### PR DESCRIPTION
Windows Server 2022 requires 2 modifications to registry to disable UAC. WIndows Server 2019 requires 1 key to be modified. This fix will apply the second requires registry change to windows server 2022.