### PR TITLE
windows: set git force to yes

### DIFF
--- a/roles/windows-executor/tasks/install_buildagent_prereq.yml
+++ b/roles/windows-executor/tasks/install_buildagent_prereq.yml
@@ -19,6 +19,7 @@
     state: '{{ package_state }}'
     package_params: '"/GitAndUnixToolsOnPath"'
     version: '{{ git_version }}'
+    force: yes
 
 - name: Install git-lfs
   win_chocolatey:


### PR DESCRIPTION
Setting force to yes because the build is saying git is already installed at a lesser version. 