### PR TITLE
fix: ruby install

### DIFF
--- a/roles/linux-executor/defaults/main/install_ruby_vars.yml
+++ b/roles/linux-executor/defaults/main/install_ruby_vars.yml
@@ -1,4 +1,2 @@
 ruby_version: 3.1.2
-rvm_dir: '/opt/circleci/.rvm'
-rvmrc_file: '{{ circleci_home }}/.rvmrc'
 gemrc_file: '{{ circleci_home }}/.gemrc'

--- a/roles/linux-executor/tasks/install_ruby.yml
+++ b/roles/linux-executor/tasks/install_ruby.yml
@@ -26,15 +26,6 @@
           - https://rubygems.org
           gem:  --no-ri --no-rdoc
 
-    - name: install ruby
-      become: true
-      become_method: sudo
-      shell: |
-        git clone https://github.com/rbenv/ruby-build.git
-        PREFIX=/usr/local sudo ./ruby-build/install.sh
-        rbenv install {{ ruby_version }}
-        rbenv global {{ ruby_version }}
-
     - name: Install rubygems (ruby-dev)
       apt:
         name: ruby-dev
@@ -43,3 +34,13 @@
 
   become: true
   become_method: sudo
+
+- name: install ruby
+  become: true
+  become_user: "{{ circleci_user }}"
+  become_method: sudo
+  shell: |
+    git clone https://github.com/rbenv/ruby-build.git
+    PREFIX=/usr/local sudo ./ruby-build/install.sh
+    rbenv install {{ ruby_version }}
+    rbenv global {{ ruby_version }}


### PR DESCRIPTION
ruby was not available when checking the version and was due to being installed on root rather than locally for the circleci user. this installs it using the cci user