### PR TITLE
windows: removed hyper-v and docker desktop

### DIFF
--- a/roles/windows-executor/files/install_servicefabric_sdk.ps1
+++ b/roles/windows-executor/files/install_servicefabric_sdk.ps1
@@ -1,9 +1,3 @@
 Set-ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
-
-param 
-( 
-        [Parameter(Mandatory=$True,Position=1)]
-        [string]$servicefabricsdk_version
-)
-
+$servicefabricsdk_version = $args[1]
 choco install service-fabric-sdk --version $servicefabricsdk_version -y

--- a/roles/windows-executor/tasks/disable_windows_services.yml
+++ b/roles/windows-executor/tasks/disable_windows_services.yml
@@ -29,15 +29,3 @@
     type: dword
     state: present
 
-- name: Enable Hyper-V
-  ansible.windows.win_powershell:
-    script: |
-      Install-WindowsFeature -Name Hyper-V -IncludeManagementTools -Restart
-
-- name: Reboot the machine after enabling Hyper-V
-  ansible.windows.win_reboot:
-
-- name: Display windows features to check if Hyper-V is enabled
-  ansible.windows.win_powershell:
-    script: |
-      Get-WindowsFeature

--- a/roles/windows-executor/tasks/install_dev_tools.yml
+++ b/roles/windows-executor/tasks/install_dev_tools.yml
@@ -91,12 +91,11 @@
     path: '{{ nodejs_dir }}'
     state: absent
 
-- name: Install docker desktop
-  win_chocolatey:
-    name: docker-desktop
-    state: '{{ package_state }}'
-    version: '{{ docker_desktop_version }}'
-    force: yes
+- name: Install docker
+  ansible.windows.win_powershell:
+    script: |
+      Install-Module DockerMsftProvider -Force
+      Install-Package Docker -ProviderName DockerMsftProvider -Force
 
 - name: Docker requires a reboot. Reboot the machine
   ansible.windows.win_reboot:


### PR DESCRIPTION
removed hyper-v enabling and docker desktop. Need to check with legal team to see if we can include docker desktop and need more time for testing changes of this magnitude. Will revisit for October release assuming there is no legal issues with doing so.