### PR TITLE
feat: download + install .deb firefox

### DIFF
--- a/roles/linux-executor/tasks/install_firefox.yml
+++ b/roles/linux-executor/tasks/install_firefox.yml
@@ -1,19 +1,37 @@
 # !file: roles/linux-executor/tasks/install_firefox.yml
 - block:
-  - name: Setup apt-pinning so we can still get a deb of Firefox instead of a snap - firefox.list
-    lineinfile:
-      path: '/etc/apt/sources.list.d/firefox.list'
-      line: 'deb http://us.archive.ubuntu.com/ubuntu/ focal-updates main'
-      create: yes
-      
-  - name: Setup apt-pinning so we can still get a deb of Firefox instead of a snap - firefox.pref
+  - name: Add mozilla ppa
+    shell: add-apt-repository ppa:mozillateam/ppa
+
+  - name: Remove firefox via shell 
+    shell:
+      apt remove firefox
+
+  - name: Remove firefox with apt module
+    apt:
+      pkg: firefox
+      state: absent
+      purge: true
+
+  - name: Blacklist snap firefox
     blockinfile:
-      path: '/etc/apt/preferences.d/firefox.pref'
+      path: '/etc/apt/preferences'
       create: yes
       block: |
         Package: firefox
-        Pin: release n=focal
-        Pin-Priority: 500
+        Pin: version 1:1snap1-0ubuntu2
+        Pin-Priority: 99
+
+  - name: Prioritze apt/debian download of firefox
+    blockinfile:
+      path: '/etc/apt/preferences.d/mozilla-firefox'
+      marker_begin: "firefox"
+      marker_end: "firefox"
+      create: yes
+      block: |
+        Package: *
+        Pin: release o=LP-PPA-mozillateam
+        Pin-Priority: 1001
 
   - name: Install firefox
     apt:


### PR DESCRIPTION
removes the old pinning way of downloading the focal version of firefox. Since jammy moved to using snap as the download/package manager we now need to set pin priorities. This removes the snap version and installs an apt/.deb version of firefox that the mozilla team maintains.