### PR TITLE
fix: use FQCN user module

### DIFF
--- a/roles/linux-executor/tasks/create_users.yml
+++ b/roles/linux-executor/tasks/create_users.yml
@@ -25,7 +25,7 @@
     when: "'circleci' not in ansible_facts.getent_group"
 
   - name: Ensure circleci user exists
-    user:
+    ansible.builtin.user:
       name: circleci
       comment: CircleCI
       uid: 1001
@@ -56,3 +56,6 @@
 
   become: true
   become_method: sudo
+
+  collections:
+    - ansible.builtin.user


### PR DESCRIPTION
the shorthand version of the `user` module was breaking lint. it is also safer to use the FQCN here in case there are conflicts with other moduls