### PR TITLE
fix: acl package is needed for temp directory reads

### DIFF
--- a/roles/linux-executor/tasks/prep_system.yml
+++ b/roles/linux-executor/tasks/prep_system.yml
@@ -103,6 +103,7 @@
           - protobuf-compiler
           - unzip
           - zip
+          - acl
         state: latest
         update_cache: true
 


### PR DESCRIPTION
AWS security functions a bit differently from GCP, which doesn't allow reading from temp directories. setfacl, included as part of the acl package fixes this