### PR TITLE
fix: revert rbenv due to lag in image update when testing

### DIFF
--- a/roles/linux-executor/tasks/install_ruby.yml
+++ b/roles/linux-executor/tasks/install_ruby.yml
@@ -34,13 +34,16 @@
         state: present
         update_cache: yes
 
-    - name: install ruby
-      shell: |
-        git clone https://github.com/rbenv/ruby-build.git
-        PREFIX=/usr/local sudo ./ruby-build/install.sh
-        rbenv install {{ ruby_version }}
-        rbenv global {{ ruby_version }}
+  become: true
+  become_method: sudo
 
+- name: install ruby
   become: true
   become_user: "{{ circleci_user }}"
   become_method: sudo
+  shell: |
+    git clone https://github.com/rbenv/ruby-build.git
+    PREFIX=/usr/local sudo ./ruby-build/install.sh
+    rbenv install {{ ruby_version }}
+    rbenv global {{ ruby_version }}
+    


### PR DESCRIPTION
there was lag when the canary images did not update, resulting in a change to the ruby path when trying to fix when in fact these permissions are what correctly configure the image.

there is currently no .config included so that's why checks are failing