### PR TITLE
fix: make only one global version default, but all available

### DIFF
--- a/roles/linux-executor/defaults/main/install_python_vars.yml
+++ b/roles/linux-executor/defaults/main/install_python_vars.yml
@@ -2,10 +2,6 @@ python_versions:
   - 2.7.18
   - 3.10.5
 
-python2_version: 2.7.18
-
-python3_version: 3.10.5
-
 pyenv_version: "v2.3.3"
 
 pyenv_dir: '/home/circleci/.pyenv'

--- a/roles/linux-executor/tasks/install_python.yml
+++ b/roles/linux-executor/tasks/install_python.yml
@@ -65,4 +65,5 @@
 - name: set pyenv global versions
   become: true
   become_method: sudo
-  shell: sudo -H -i -u {{ circleci_user }} {{ pyenv_dir }}/bin/pyenv global {{ python2_version }} {{ python3_version }}
+  shell: sudo -H -i -u {{ circleci_user }} {{ pyenv_dir }}/bin/pyenv global {{ item }}
+  with_items: '{{ python_versions }}'


### PR DESCRIPTION
when setting global versions for pyenv similar to machine-executor-images, the in-line addition of both versions would actually make both versions (2.7.18 and 3.10.5) global, however, the 2.7.18 version would take precedence, which is not the desired outcome. using a loop would set both as global versions available, but only the second one would be the default