### PR TITLE
refactor: add new linux_configure config file

### DIFF
--- a/playbooks/linux/linux_configure.yml
+++ b/playbooks/linux/linux_configure.yml
@@ -5,6 +5,28 @@
   hosts: all
   connection: local
   roles:
-    - ../../../roles/linux-executor
+    - system_prep
+    - base
+    - cci_specific
+    - sysadmin_tools
+    - devtools
+    - ant
+    - socat
+    - nsenter
+    - jq
+    - yq
+    - python3
+    - java
+    - firefox
+    - chrome
+    - awscli
+    - gcloud
+    - node
+    - clojure
+    - ruby
+    - golang
+    - scala
+    - docker
+    - dpkg_configure
   vars_files:
     - linux_configure_vars.yml

--- a/playbooks/linux/linux_configure_vars.yml
+++ b/playbooks/linux/linux_configure_vars.yml
@@ -5,3 +5,5 @@ remote_user: circleci
 ssh_private_key_file: ~/project/gce_googlecompute.pem
 ssh_authorized_key_file: ~/.ssh/id_rsa.pub
 become_method: sudo
+circleci_user: circleci
+circleci_home: /home/circleci


### PR DESCRIPTION
Instead of the original linux_configure file, we are now going to modularize the process using roles and use playbooks as intended - as an overarching configuration file to oversee which roles will be installed for a specific installation.

In this use case, this specific linux_configure build would create an amd64 image for linux ubuntu 22.04. An example of how this would be helpful is to specify an additional playbook for linux_configure_arm64, or linux_configure_android, with the key differences being architecture or additional packages for android.

In the case of amd64 vs arm64, it may not be known the incompatibilities, and therefore it may be worth having separate playbooks, however, the easier way is to use dpkg --print-architecture to download the correct packages for each image