### PR TITLE
refactor: add registered variable and refactor architecture variable usage

### DIFF
--- a/roles/awscli/tasks/main.yml
+++ b/roles/awscli/tasks/main.yml
@@ -1,29 +1,35 @@
 ---
 - block:
-  # will need to account for arch
-    - name: download awscli
-      get_url:
-        url: 'https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip'
+    - name: Download awscli (arm64)
+      ansible.builtin.get_url:
+        url: "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip"
         dest: '/tmp/awscliv2.zip'
+      when: arch == "arm64" or arch == "aarch64"
 
-    - name: extract awscli
-      unarchive:
+    - name: Download awscli (amd64)
+      ansible.builtin.get_url:
+        url: "https://awscli.amazonaws.com/awscli-exe-linux-{{ ansible_facts.architecture }}.zip"
+        dest: '/tmp/awscliv2.zip'
+      when: arch == "amd64" or arch == "x86_64"
+
+    - name: Extract awscli
+      ansible.builtin.unarchive:
         src: '/tmp/awscliv2.zip'
         dest: '/tmp'
 
-    - name: install awscli
-      shell: |
+    - name: Install awscli
+      ansible.builtin.shell: |
         cd /tmp
         ./aws/install -i /usr/local/aws-cli -b /usr/local/bin \
         || ./aws/install --update -i /usr/local/aws-cli -b /usr/local/bin
 
-    - name: remove awscli
-      file:
+    - name: Remove awscli
+      ansible.builtin.file:
         path: '/tmp/awscliv2.zip'
         state: absent
 
-    - name: configure AWS_PAGER in .circlerc
-      lineinfile:
+    - name: Configure AWS_PAGER in .circlerc
+      ansible.builtin.lineinfile:
         path: '{{ circleci_home }}/.circlerc'
         line: 'export AWS_PAGER=""'
         create: yes

--- a/roles/chrome/tasks/main.yml
+++ b/roles/chrome/tasks/main.yml
@@ -5,10 +5,10 @@
       url: 'https://dl-ssl.google.com/linux/linux_signing_key.pub'
       state: present
 
-  - name: Add downloadlink for debian chrome to source list
+  - name: Add download link for debian chrome to source list
     ansible.builtin.lineinfile:
       path: '/etc/apt/sources.list.d/google-chrome.list'
-      line: 'deb [arch={{ arch }}] http://dl.google.com/linux/chrome/deb/ stable main'
+      line: 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main'
       create: yes
 
   - name: Install google chrome
@@ -33,3 +33,4 @@
       chromedriver --version
 
   become: true
+  when: arch == "amd64" or arch == "x86_64"

--- a/roles/gcloud/tasks/main.yml
+++ b/roles/gcloud/tasks/main.yml
@@ -1,8 +1,4 @@
 ---
-- name: Register correct architecture
-  ansible.builtin.shell: dpkg --print-architecture
-  register: dpkg_architecture
-
 - block:
     - name: Create /opt/google directory
       ansible.builtin.file:
@@ -15,13 +11,13 @@
       ansible.builtin.get_url:
         url: "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-{{ gcloud_version }}-linux-arm.tar.gz"
         dest: "/tmp/gcloud.tar.gz"
-      when: dpkg_architecture.rc == arm64
+      when: arch == "arm64" or arch == "aarch64"
 
     - name: Download gcloud (amd64)
       ansible.builtin.get_url:
-        url: "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-{{ gcloud_version }}-linux-x86_64.tar.gz"
+        url: "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-{{ gcloud_version }}-linux-{{ ansible_facts.architecture }}.tar.gz"
         dest: "/tmp/gcloud.tar.gz"
-      when: dpkg_architecture.rc == amd64
+      when: arch == "amd64" or arch == "x86_64"
 
     - name: Extract gcloud
       ansible.builtin.unarchive:

--- a/roles/system_prep/tasks/main.yml
+++ b/roles/system_prep/tasks/main.yml
@@ -1,4 +1,13 @@
 ---
+- name: Register machine architecture
+  become: true
+  ansible.builtin.shell: dpkg --print-architecture
+  register: arch_string
+
+- name: Set fact for architecture
+  ansible.builtin.set_fact:
+    arch: "{{ arch_string.stdout }}"
+
 - block:
   - name: Get available users
     getent:


### PR DESCRIPTION
This PR: 
- Uses the system_prep role to register the architecture of the host machine when building
- Refactors logic used for various downloads that are dependent on arm/amd/x86_64 differentiators in their download links
- the java and yq roles now have access to the {{ arch }} variable. golang in PR #126 will also have it once merged
- the chrome role is now only activated when the architecture is x86_64/amd64 since they do not have a separate download link for arm, consistent with the current build process
