### PR TITLE
adds manifest

### DIFF
--- a/manifest/software.json
+++ b/manifest/software.json
@@ -1,0 +1,30 @@
+{
+  "ruby": [
+    "3.1.2"
+  ],
+  "node": [
+    "16.16.0",
+    "current"
+  ],
+  "npmGlobal": [
+    "npm",
+    "coffeescript",
+    "bower",
+    "grunt-cli",
+    "nodeunit",
+    "mocha",
+    "yarn"
+  ],
+  "npmLocal": [
+    "grunt"
+],
+  "python": [
+    "2.7.18",
+    "3.10.5"
+  ],
+  "defaults": {
+    "ruby": "3.1.2",
+    "node": "16.16.0",
+    "python": "3.10.5"
+  }
+}


### PR DESCRIPTION
adds a manifest that can be invoked with extra args in the command line when running ansible-playbook and allows for easier parsing when tracking the manifest

While this specific repo does not have a packer.json/yaml, this is technically part of the machine-executor flow. However, one can be included at a later date with correct credentials