### PR TITLE
fix: docker flag

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -32,7 +32,6 @@
           - docker-compose-plugin={{ docker_compose_version }}
         state: present
         allow_downgrade: yes
-        allow_change_held_packages: yes
         force: yes
         update_cache: yes
 


### PR DESCRIPTION
the allow_change_held_packages flag should technically be available in the ansible version being used, but is not. there does not seem to be any conflicts, so removing it.