### PR TITLE
refactor: remove apt update in base; not needed

### DIFF
--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -4,12 +4,6 @@
         autoremove: yes
         autoclean: yes
 
-    - name: Update and upgrade apt packages
-      ansible.builtin.apt:
-        upgrade: true
-        update_cache: true
-        cache_valid_time: 86400 #One day
-
     - name: Remove snapd - it inteferes with what we want such as .deb Firefox
       ansible.builtin.apt:
         pkg: snapd


### PR DESCRIPTION
there is no need to have this step as the apt modules in subsequent steps will update/upgrade. this actually occasionally kills the build