### PR TITLE
refactor: remove conditionals for user and group checking

### DIFF
--- a/roles/system_prep/tasks/main.yml
+++ b/roles/system_prep/tasks/main.yml
@@ -22,14 +22,12 @@
       name: aws-sudoers
       gid: 1001
       non_unique: yes
-    when: "'aws-sudoers' not in ansible_facts.getent_group"
 
   - name: Ensure circleci group exists
     group:
       name: "{{ circleci_user }}"
       gid: 1002
       non_unique: yes
-    when: "'circleci' not in ansible_facts.getent_group"
 
   - name: Ensure circleci user exists
     ansible.builtin.user:
@@ -40,8 +38,8 @@
       group: "{{ circleci_user }}"
       groups: aws-sudoers,adm,audio,cdrom,dialout,dip,floppy,lxd,netdev,plugdev,video,ubuntu
       append: yes
+      password: ''
       password_lock: yes
-    when: "'circleci' not in ansible_facts.getent_passwd"
   
   - name: Ensure .ssh directory exists for circleci user
     ansible.builtin.file:


### PR DESCRIPTION
removed conditional as this role will be working off a blank image in the first place where these users and groups should not exist in the first place.

- this may need to be edited when the canaries are being built. i cannot check it right now
- added a ' ' for the password, since this is the only way the password is disabled (vs '!' or '*') in ansible docs.