### PR TITLE
Add other testing for manifest

### DIFF
--- a/manifest/software.json
+++ b/manifest/software.json
@@ -1,7 +1,40 @@
 {
-  "ruby": [
-    "3.1.2"
+  "aws-cli": "2.8.7",
+  "docker": {
+    "docker": "20.10.17",
+    "docker-compose": "2.6.0",
+    "containerd": "1.6.4"
+  },
+  "gcloud": "393.0.0",
+  "gradle": "7.5",
+  "installed_packages": [
+    "firefox",
+    "google-chrome",
+    "ant",
+    "build-essential",
+    "libncurses5-dev",
+    "libslang2-dev",
+    "gettext",
+    "zlib1g-dev",
+    "libselinux1-dev",
+    "debhelper",
+    "lsb-release",
+    "pkg-config",
+    "po-debconf",
+    "autoconf",
+    "automake",
+    "autopoint",
+    "libtool",
+    "util-linux",
+    "socat",
+    "htop"
   ],
+  "java": [
+    "11",
+    "17"
+  ],
+  "lein": "2.9.8",
+  "maven": "3.8.6",
   "node": {
     "lts": "16.16.0",
     "current": "18.6.0"
@@ -17,19 +50,26 @@
   ],
   "npmLocal": [
     "grunt"
-],
+  ],
   "python": [
     "2.7.18",
     "3.10.5"
   ],
+  "defaults": {
+    "go": "1.18.4",
+    "node": "16.16.0",
+    "python": "3.10.5",
+    "java": "17",
+    "ruby": "3.1.2",
+    "sbt": "1.6.2",
+    "win_pyenv": "3.10.6",
+    "yq": "4.24.5"
+  },
+  "ruby": [
+    "3.1.2"
+  ],
   "win_pyenv": [
     "3.10.6",
     "miniconda3-3.9-4.12.0"
-  ],
-  "defaults": {
-    "ruby": "3.1.2",
-    "node": "16.16.0",
-    "python": "3.10.5",
-    "win_pyenv": "3.10.6"
-  }
+  ]
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,3 +17,7 @@ def dotfile():
       return "/home/circleci/.circlerc"
     else:
       return "~/.bashrc"
+      
+@pytest.fixture
+def machine_arch():
+    return platform.uname().machine

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,4 +1,5 @@
 import subprocess
+import os
 
 class TestManifest:
   def test_ruby_versions(self, manifest):
@@ -54,14 +55,74 @@ class TestManifest:
     assert missing == '', f"The python interpreter is missing or is not correctly set to: {python_interpreter}"
 
   def test_python(self, manifest):
-      installed_pythons = subprocess.run(['pyenv', 'versions'], capture_output=True).stdout.decode("utf-8")
-      missing = ''
-      for python in manifest['python']:
-          if installed_pythons.find(python) == -1:
-              missing += f"{python}"
-      assert missing == '', f"The following Python versions are missing: {missing}"
+    installed_pythons = subprocess.run(['pyenv', 'versions'], capture_output=True).stdout.decode("utf-8")
+    missing = ''
+    for python in manifest['python']:
+      if installed_pythons.find(python) == -1:
+        missing += f"{python}"
+    assert missing == '', f"The following Python versions are missing: {missing}"
 
   def test_default_python(self, manifest):
-      python_default = subprocess.run(['python3', '--version'], capture_output=True).stdout.decode("utf-8")
-      assert python_default.find(manifest['defaults']['python']) != -1, f"The default Python should be {manifest['defaults']['python']} but found {python_default}!"
+    python_default = subprocess.run(['python3', '--version'], capture_output=True).stdout.decode("utf-8")
+    assert python_default.find(manifest['defaults']['python']) != -1, f"The default Python should be {manifest['defaults']['python']} but found {python_default}!"
 
+  def test_go(self, manifest):
+    go_version = subprocess.run(['go', 'version'], capture_output=True).stdout.decode("utf-8")
+    assert go_version.find(manifest['defaults']['go']) != -1, f"Go was not found or the version is incorrect. Output: {go_version}"
+
+  def test_gradle(self, manifest):
+    gradle = subprocess.run(['gradle', '--version'], capture_output=True).stdout.decode("utf-8")
+    assert gradle.find(manifest['gradle']) != -1, f"Gradle was not found or the version is incorrect. Output: {gradle}"
+
+  def test_maven(self, manifest):
+    maven = subprocess.run(['mvn', '--version'], capture_output=True).stdout.decode("utf-8")
+    assert maven.find(manifest['maven']) != -1, f"Maven was not found or the version is incorrect. Output: {maven}"
+
+  def test_clojure(self, manifest):
+    lein = subprocess.run(['lein', '--version'], capture_output=True).stdout.decode("utf-8")
+    assert lein.find(manifest['lein']) != -1, f"Lein was not found or the version is incorrect. Output: {lein}"
+
+  def test_awscli(self, manifest):
+    aws = subprocess.run(['aws', '--version'], capture_output=True).stdout.decode("utf-8")
+    assert aws.find(manifest['aws-cli']) != -1, f"aws-cli was not found or the version is incorrect. Output: {aws}"
+
+  def test_docker(self, manifest):
+    for package in manifest['docker']:
+      missing = ''
+      version = subprocess.run([package, '--version'], capture_output=True).stdout.decode("utf-8")
+      if version.find(package) == -1:
+        missing += f"{package}"
+    assert missing == '', f"The following packages for Docker are missing: {missing}"
+
+  def test_gcloud(self, manifest):
+    gcloud  = subprocess.run(['gcloud', '--version'], capture_output=True).stdout.decode("utf-8")
+    assert gcloud.find(manifest['gcloud']) != -1, f"gcloud was not found or the version is incorrect. Output: {gcloud}"
+
+  def test_chrome(self):
+    chrome = subprocess.run(['google-chrome', '--version'], capture_output=True)
+    assert chrome.returncode != -1, f"Chrome was not found. Output: {chrome}"
+
+  def test_firefox(self):
+    firefox = subprocess.run(['firefox', '--version'], capture_output=True)
+    assert firefox.returncode != -1, f"Firefox was not found. Output: {firefox}"
+
+  def test_scala(self, manifest):
+    sbt = subprocess.run(['sbt', '-V'], capture_output=True).stdout.decode("utf-8")
+    assert sbt.find(manifest['defaults']['sbt']) != -1, f"sbt/scala was not found or the version is incorrect. Output: {sbt}"
+
+  def test_default_java(self, manifest):
+    java = subprocess.run(['java', '--version'], capture_output=True).stdout.decode("utf-8")
+    assert java.find(manifest['defaults']['java']) != -1, f"The default version of Java was not found or is incorrect. Output: {java}"
+
+  def test_java_versions(self, manifest):
+    path = "/usr/lib/jvm/java--openjdk-{{ arch }}/bin/java"
+    missing = ''
+    for version in manifest['java']:
+        path = "/usr/lib/jvm/java-{version}-openjdk-{machine_arch}/bin/java"
+        if os.path.exists(path) == -1:
+          missing += f"{version}"
+    assert missing == '', f"Java was not found or is missing. Output: {missing}"
+
+  def test_yq(self, manifest):
+    yq = subprocess.run(['yq', '--version'], capture_output=True).stdout.decode("utf-8")
+    assert yq.find(manifest['defaults']['yq']) != -1, f"yq was not found or the version is incorrect. Output: {yq}"

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -115,7 +115,6 @@ class TestManifest:
     assert java.find(manifest['defaults']['java']) != -1, f"The default version of Java was not found or is incorrect. Output: {java}"
 
   def test_java_versions(self, manifest):
-    path = "/usr/lib/jvm/java--openjdk-{{ arch }}/bin/java"
     missing = ''
     for version in manifest['java']:
         path = "/usr/lib/jvm/java-{version}-openjdk-{machine_arch}/bin/java"


### PR DESCRIPTION
- adds additional manifest information in a centralized store. also alphabetizes
- adds rest of the tests. installed apt packages may need to be added sometime later
- adds platform fixture to help with tracking down java versions
- fixes indentation in some tests