### PR TITLE
refactor: use named aliases for node and convert node object/dict to …

### DIFF
--- a/manifest/software.json
+++ b/manifest/software.json
@@ -2,10 +2,10 @@
   "ruby": [
     "3.1.2"
   ],
-  "node": {
-    "lts": "16.16.0",
-    "current": "18.6.0"
-  },
+  "node": [
+    "lts",
+    "current"
+  ],
   "npmGlobal": [
     "npm",
     "coffeescript",
@@ -28,7 +28,7 @@
   ],
   "defaults": {
     "ruby": "3.1.2",
-    "node": "16.16.0",
+    "node": "lts",
     "python": "3.10.5",
     "win_pyenv": "3.10.6"
   }

--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -19,11 +19,11 @@
         group: "{{ circleci_user }}"
         recurse: true
       become: true
-    
+
     - name: Set safe directory
       ansible.builtin.shell:
         git config --global --add safe.directory '*'
-      args: 
+      args:
         chdir: "{{ nvm_dir }}"
 
     - name: Set tag to latest
@@ -47,7 +47,7 @@
           export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"
           [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
           [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
-          
+
     - name: Set nvm dir with correct permissions recursively after running script
       ansible.builtin.file:
         path: "{{ nvm_dir }}"
@@ -62,7 +62,8 @@
       nvm:
         versions: "{{ node }}"
         default: "{{ defaults.node }}"
-        npm: "{{ npm }}"
+        npmGlobal: "{{ npmGlobal }}"
+        npmLocal: "{{ npmLocal }}"
 
   when: nvm_installed.rc == 1
 


### PR DESCRIPTION
- Ansible custom module args does not play nice with objects, so changing variables to an array/list.
- Also utilizing aliases since we will always install the lts and current versions 