### PR TITLE
feat: add step to remove sbt created folders

### DIFF
--- a/roles/scala/tasks/main.yml
+++ b/roles/scala/tasks/main.yml
@@ -1,14 +1,15 @@
 ---
-- block:
-    - name: Install sbt
-      ansible.builtin.apt:
-        deb: https://scala.jfrog.io/artifactory/debian/sbt-{{ sbt_version }}.deb
+- name: Install sbt
+  become: true
+  ansible.builtin.apt:
+    deb: https://scala.jfrog.io/artifactory/debian/sbt-{{ sbt_version }}.deb
 
+- block:
     - name: Remove sbt .deb file
       ansible.builtin.file:
         path: "sbt-{{ sbt_version }}.deb"
         state: absent
-    
+
     - name: Create and set permissions for sbt cache
       ansible.builtin.file:
         path: "{{ circleci_home }}/.cache"
@@ -22,11 +23,14 @@
         owner: "{{ circleci_user }}"
         group: "{{ circleci_user }}"
         state: directory
-        
-    - name: Display sbt version
-      ansible.builtin.shell: sbt -V
 
     - name: Display sbt version
       ansible.builtin.shell: sudo -u {{ circleci_user }} sbt -V
+
+    - name: Remove sbt created folders
+      ansible.builtin.file:
+        path: "{{ circleci_home }}/{{ item }}"
+        state: absent
+      with_items: "{{ folders }}"
 
   become: true

--- a/roles/scala/vars/main.yml
+++ b/roles/scala/vars/main.yml
@@ -2,3 +2,6 @@
 circleci_user: circleci
 circleci_home: /home/circleci
 sbt_version: 1.6.2
+folders:
+  - project
+  - target


### PR DESCRIPTION
sbt -V creates folders that we do not want or need. additionally, it interferes with the circleci build process due to the project folder. 