### PR TITLE
refactor: grunt and grunt-cli can be installed again. refactor the co…

### DIFF
--- a/manifest/software.json
+++ b/manifest/software.json
@@ -6,18 +6,16 @@
     "lts",
     "current"
   ],
-  "npmGlobal": [
+  "npm": [
     "npm",
     "coffeescript",
-    "bower",
     "grunt-cli",
+    "grunt",
+    "bower",
     "nodeunit",
     "mocha",
     "yarn"
   ],
-  "npmLocal": [
-    "grunt"
-],
   "python": [
     "2.7.18",
     "3.10.5"

--- a/roles/node/library/nvm.py
+++ b/roles/node/library/nvm.py
@@ -8,8 +8,7 @@ def main():
     args = dict(
         versions=dict(type='list', elements='str', required=True),
         default=dict(type='str', required=False),
-        npmGlobal=dict(type='list', elements='str', required=False),
-        npmLocal=dict(type='list', elements='str', required=False),
+        npm=dict(type='list', elements='str', required=False)
     )
 
     module = AnsibleModule(
@@ -19,8 +18,7 @@ def main():
 
     versions = module.params['versions']
     default = module.params['default']
-    npmGlobal = module.params['npmGlobal']
-    npmLocal = module.params['npmLocal']
+    npm = module.params['npm']
 
     for version in versions:
         if version == 'lts':
@@ -40,14 +38,10 @@ def main():
         if subprocess.run(['/bin/bash', '-i', '-c', 'source /home/circleci/.circlerc && nvm use default']).returncode != 0:
             module.fail_json(msg='Failed to set default NodeJS version!')
 
-    if npmGlobal:
-        for package in npmGlobal:
+    if npm:
+        for package in npm:
             if subprocess.run(['/bin/bash', '-lc', 'source /home/circleci/.circlerc && npm install -g ' + package]).returncode != 0:
                 module.fail_json(msg='Failed to install ' + package + ' globally with npm!')
-    if npmLocal:
-        for package in npmLocal:
-            if subprocess.run(['/bin/bash', '-lc', 'source /home/circleci/.circlerc && npm install ' + package]).returncode != 0:
-                module.fail_json(msg='Failed to install ' + package + ' locally with npm!')
 
     module.exit_json(changed=True)
 

--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -7,18 +7,18 @@
   register: nvm_installed
 
 - block:
-    - name: Download NVM
-      ansible.builtin.git:
-        repo: https://github.com/nvm-sh/nvm.git
-        dest: "{{ nvm_dir }}"
-
     - name: Ensure correct permissions
       ansible.builtin.file:
         path: "{{ nvm_dir }}"
         owner: "{{ circleci_user }}"
         group: "{{ circleci_user }}"
-        recurse: true
-      become: true
+        mode: 0755
+        state: directory
+
+    - name: Download NVM
+      ansible.builtin.git:
+        repo: https://github.com/nvm-sh/nvm.git
+        dest: "{{ nvm_dir }}"
 
     - name: Set safe directory
       ansible.builtin.shell:
@@ -62,8 +62,7 @@
       nvm:
         versions: "{{ node }}"
         default: "{{ defaults.node }}"
-        npmGlobal: "{{ npmGlobal }}"
-        npmLocal: "{{ npmLocal }}"
+        npm: "{{ npm }}"
 
   when: nvm_installed.rc == 1
 

--- a/tests/linux/test_manifest.py
+++ b/tests/linux/test_manifest.py
@@ -29,20 +29,12 @@ class TestManifest:
   def test_default_node(self, manifest, dotfile):
     node_default = subprocess.run(['/bin/bash', '-lc', 'source ' + dotfile + ' && nvm ls --no-colors | grep "default ->"'], capture_output=True).stdout.decode("utf-8")
     assert node_default.find(manifest['defaults']['node']) != -1, f"The default NodeJS should be {manifest['defaults']['node']} but found {node_default}!"
-  
-  def test_npm_local_packages(self, manifest):
-    npmLocal = subprocess.run(['npm', 'list'], capture_output=True).stdout.decode("utf-8")
+
+  def test_npm_packages(self, manifest):
+    npm = subprocess.run(['npm', 'list', '-g'], capture_output=True).stdout.decode("utf-8")
     missing = ''
-    for localPackages in manifest['npmLocal']:
-      if npmLocal.find(localPackages) == -1:
-        missing += f"{localPackages} "
-    assert missing == '', f"The following local npm packages are missing: {localPackages}"
-        
-  def test_npm_global_packages(self, manifest):
-    npmGlobal = subprocess.run(['npm', 'list', '-g'], capture_output=True).stdout.decode("utf-8")
-    missing = ''
-    for globalPackages in manifest['npmGlobal']:
-      if npmGlobal.find(globalPackages) == -1:
+    for globalPackages in manifest['npm']:
+      if npm.find(globalPackages) == -1:
         missing += f"{globalPackages} "
     assert missing == '', f"The following global npm packages are missing: {globalPackages}"
 
@@ -64,4 +56,3 @@ class TestManifest:
   def test_default_python(self, manifest):
       python_default = subprocess.run(['python3', '--version'], capture_output=True).stdout.decode("utf-8")
       assert python_default.find(manifest['defaults']['python']) != -1, f"The default Python should be {manifest['defaults']['python']} but found {python_default}!"
-


### PR DESCRIPTION
grunt and grunt-cli was having trouble installing globally. i just ran it in a role and it seems to be working fine.
As a result, there is no need for npmLocal and npmGlobal has been renamed to npm