### PR TITLE
refactor: .ssh mode change, add ansible tmp dir, file references

### DIFF
--- a/group_vars/linux_configure_vars.yml
+++ b/group_vars/linux_configure_vars.yml
@@ -3,3 +3,4 @@
 
 circleci_user: circleci
 circleci_home: /home/circleci
+ansible_remote_tmp: "/tmp"

--- a/linux-playbook.yml
+++ b/linux-playbook.yml
@@ -1,6 +1,4 @@
 ---
-# !file: playbooks/linux/linux_configure.yml
-
 - name: Configure linux node
   hosts: all
   roles:

--- a/roles/common/tasks/cci_specific.yml
+++ b/roles/common/tasks/cci_specific.yml
@@ -12,9 +12,9 @@
     - name: check if line is in file
       ansible.builtin.blockinfile:
         path: "{{ circleci_home }}/.bashrc"
-        block: 
+        block:
           source ~/.circlerc &>/dev/null
-          if ! echo $- | grep -q "i" && [ -n "$BASH_ENV" ] && [ -f "$BASH_ENV" ]; then . "$BASH_ENV"; fi          
+          # if ! echo $- | grep -q "i" && [ -n "$BASH_ENV" ] && [ -f "$BASH_ENV" ]; then . "$BASH_ENV"; fi
         create: yes
 
     - name: Change ownership of .bash_profile
@@ -63,7 +63,7 @@
           HashKnownHosts no
           SendEnv LANG LC_*
         create: yes
-          
+
     - name: Some optimizations for the sshd daemon
       ansible.builtin.lineinfile:
         path: '/etc/ssh/sshd_config'

--- a/roles/common/tasks/system_prep.yml
+++ b/roles/common/tasks/system_prep.yml
@@ -40,12 +40,14 @@
       append: yes
       password: ''
       password_lock: yes
-  
+      state: present
+
   - name: Ensure .ssh directory exists for circleci user
     ansible.builtin.file:
       path: "{{ circleci_home }}/.ssh"
       owner: "{{ circleci_user }}"
       group: "{{ circleci_user }}"
+      mode: 0600
       state: directory
 
   - name: Ensure aws-sudoers group has passwordless sudo


### PR DESCRIPTION
Adds ansible_remote_tmp and change mode of .ssh to 0600 to accommodate AWS builds
Removes file reference at the top for linux-playbook
adds user state to present in case the user already exists
Comments out BASH_ENV sourcing for testing