### PR TITLE
chore: add folder mode changes; move safe-directory up a step

### DIFF
--- a/roles/common/tasks/cci_specific.yml
+++ b/roles/common/tasks/cci_specific.yml
@@ -45,6 +45,7 @@
           export DISPLAY=:99
           # Make Selenium tests more stable
           export DBUS_SESSION_BUS_ADDRESS=/dev/null
+        mode: 0664
         create: yes
 
     - name: Create /bin directory
@@ -112,7 +113,7 @@
     - name: Change permissions on xvfb.service
       ansible.builtin.file:
         path: "/etc/systemd/system/xvfb.service"
-        mode: "0644"
+        mode: 0644
 
     - name: Enable xvfb.service
       ansible.builtin.systemd:

--- a/roles/common/tasks/system_prep.yml
+++ b/roles/common/tasks/system_prep.yml
@@ -47,7 +47,7 @@
       path: "{{ circleci_home }}/.ssh"
       owner: "{{ circleci_user }}"
       group: "{{ circleci_user }}"
-      mode: 0600
+      mode: 0775
       state: directory
 
   - name: Ensure aws-sudoers group has passwordless sudo

--- a/roles/golang/tasks/main.yml
+++ b/roles/golang/tasks/main.yml
@@ -30,14 +30,10 @@
     - name: Make /.go_workspace directory
       ansible.builtin.file:
         path: "{{ circleci_home }}/.go_workspace"
-        state: directory
-
-    - name: Change ownership of .go_workspace directory
-      ansible.builtin.file:
-        path: "{{ circleci_home }}/.go_workspace"
         owner: "{{ circleci_user }}"
         group: "{{ circleci_user }}"
         state: directory
+        mode: 0775
         recurse: yes
 
     - name: Configure golang

--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -12,19 +12,19 @@
         path: "{{ nvm_dir }}"
         owner: "{{ circleci_user }}"
         group: "{{ circleci_user }}"
-        mode: 0755
+        mode: 0775
         state: directory
-
-    - name: Download NVM
-      ansible.builtin.git:
-        repo: https://github.com/nvm-sh/nvm.git
-        dest: "{{ nvm_dir }}"
 
     - name: Set safe directory
       ansible.builtin.shell:
         git config --global --add safe.directory '*'
       args:
         chdir: "{{ nvm_dir }}"
+
+    - name: Download NVM
+      ansible.builtin.git:
+        repo: https://github.com/nvm-sh/nvm.git
+        dest: "{{ nvm_dir }}"
 
     - name: Set tag to latest
       changed_when: false
@@ -53,7 +53,7 @@
         path: "{{ nvm_dir }}"
         owner: "{{ circleci_user }}"
         group: "{{ circleci_user }}"
-        mode: 0755
+        mode: 0775
         recurse: true
         state: directory
 

--- a/roles/python3/tasks/main.yml
+++ b/roles/python3/tasks/main.yml
@@ -5,6 +5,7 @@
         path: "{{ pyenv_dir }}"
         owner: "{{ circleci_user }}"
         group: "{{ circleci_user }}"
+        mode: 0775
         state: directory
 
     - name: Install pyenv dependencies
@@ -32,7 +33,7 @@
       # Intentionally uses shell instead of git module
       ansible.builtin.shell:
         "git clone --branch {{ pyenv_version }} --single-branch https://github.com/pyenv/pyenv.git {{ pyenv_dir }}"
-        
+
     - name: Configure pyenv
       ansible.builtin.blockinfile:
         path: "{{ circleci_home }}/.circlerc"
@@ -50,14 +51,14 @@
       pyenv:
         versions: "{{ python }}"
         default: "{{ defaults.python }}"
-    
+
     - name: Set Python for subsequent tasks
       ansible.builtin.set_fact:
         ansible_python_interpreter: "{{ pyenv_dir }}/shims/python3"
 
     - name: Install Pip Packages
       become_user: "{{ circleci_user }}"
-      ansible.builtin.pip: 
+      ansible.builtin.pip:
         name: "{{ item }}"
       with_items: "{{ pip }}"
 

--- a/roles/ruby/tasks/main.yml
+++ b/roles/ruby/tasks/main.yml
@@ -30,6 +30,7 @@
         path: "{{ gemrc_file }}"
         owner: "{{ circleci_user }}"
         group: "{{ circleci_user }}"
+        mode: 0664
         create: yes
         block: |
           :sources:
@@ -47,7 +48,7 @@
       ansible.builtin.shell: |
         git clone https://github.com/rbenv/ruby-build.git "{{ ruby_dir }}"/plugins/ruby-build
         PREFIX=/usr/local sudo "{{ ruby_dir }}/plugins/ruby-build/install.sh"
-    
+
     - name: Install ruby
       become_user: "{{ circleci_user }}"
       rbenv:
@@ -55,4 +56,3 @@
         default: "{{ defaults.ruby }}"
 
   become: true
-  

--- a/roles/scala/tasks/main.yml
+++ b/roles/scala/tasks/main.yml
@@ -22,6 +22,7 @@
         path: "{{ circleci_home }}/.sbt"
         owner: "{{ circleci_user }}"
         group: "{{ circleci_user }}"
+        mode: 0775
         state: directory
 
     - name: Display sbt version


### PR DESCRIPTION
the checkout step was failing with the error: `failed to write known_hosts entry: open /home/circleci/.ssh/known_hosts: permission denied` [here](https://app.circleci.com/pipelines/github/circleci/machine-executor-images/4379/workflows/aaf32817-77f8-4752-95ad-31e9a4db47cc/jobs/79396)

as a result, i used an existing image to match the modes across a couple of files. the 600 mode was intended for key files, rather than the directory itself

The `safe directory` for global git config was placed under the NVM download and needed to be moved up