### PR TITLE
windows: skip KB5019081 due to known issues. Fails to install due to …

### DIFF
--- a/roles/windows-executor/tasks/install_windows_updates.yml
+++ b/roles/windows-executor/tasks/install_windows_updates.yml
@@ -1,10 +1,10 @@
 # !file: roles/windows-executor/tasks/install_windows_updates.yml
 
-- name: Install all security, critical, and rollup updates
-  win_updates:
-    category_names:
-      - SecurityUpdates
-      - CriticalUpdates
-      - UpdateRollups
+- name: Install all updates and reboot as many times as needed
+  ansible.windows.win_updates:
+    category_names: '*'
     reboot: yes
+    reboot_timeout: 7200
+    reject_list:
+      - 5019081
    


### PR DESCRIPTION
Skip KB5019081 due to known Kerberos issues. Ansible is still picking up this KB but it has known issues and therefore we should filter it from being installed. 

see for more details:
https://support.microsoft.com/en-us/topic/november-8-2022-kb5019081-os-build-20348-1249-14345324-e5d1-4710-a364-76d69d7aaa7c
