### PR TITLE
windows: removed .net 7 sdk

### DIFF
--- a/roles/windows-executor/defaults/main/install_microsoft_tools_defaults.yml
+++ b/roles/windows-executor/defaults/main/install_microsoft_tools_defaults.yml
@@ -1,5 +1,4 @@
 dotnet_sdk_version_6: 6.0.403
-dotnet_sdk_version_7: 7.0.100
 sqlserver_devedition_version: 15.0.2000.20210324
 visualstudio_community_edition_version:  117.4.1.0
 visualstudio_buildtools_version: 117.4.1.0

--- a/roles/windows-executor/tasks/install_microsoft_tools.yml
+++ b/roles/windows-executor/tasks/install_microsoft_tools.yml
@@ -7,13 +7,6 @@
     version: '{{ dotnet_sdk_version_6}}'
     force: yes
 
-- name: Install dotnet sdk 7
-  win_chocolatey:
-    name: dotnet-sdk
-    state: '{{ package_state }}'
-    version: '{{ dotnet_sdk_version_7}}'
-    force: yes
-
 #- name: Install Sql Server Developer Edition
 #  win_chocolatey:
 #    name: sql-server-2019


### PR DESCRIPTION
remove .net 7 sdk due to install installing side-by-side with .net 6 sdk. 

Chocolatey no longer supports side-by-side installations.
https://docs.chocolatey.org/en-us/choco/commands/install

Will look into installing .net 7 sdk and .net 6 sdk outside of chocolatey in a future release