### PR TITLE
Windows: Server 2022 March 2023 updates

### DIFF
--- a/roles/windows-executor/defaults/main/install_cloud_tools_defaults.yml
+++ b/roles/windows-executor/defaults/main/install_cloud_tools_defaults.yml
@@ -1,4 +1,4 @@
-awscli_version: 2.10.1
+awscli_version: 2.10.3
 azurecli_version: 2.45.0
 webpi_version: 5.1
 servicefabric_version: 9.1.1390

--- a/roles/windows-executor/defaults/main/install_dev_tools_defaults.yml
+++ b/roles/windows-executor/defaults/main/install_dev_tools_defaults.yml
@@ -1,12 +1,12 @@
-nunit_console_runner_version: 3.16.2
-nano_version: 7.2.14
-vim_version: 9.0.1221
+nunit_console_runner_version: 3.16.3
+nano_version: 7.2.17
+vim_version: 9.0.1365
 jq_version: 1.6
 golang_version: 1.20.1
 openjdk_version: 19.0.2
 miniconda3_version: 4.12.0
 python_3_version: 3.11.0
-nodejs_version: 19.6.0
+nodejs_version: 19.7.0
 ruby_version: 3.1.3.1
 docker_version: 20.10.21
 docker_desktop_version: 4.16.3

--- a/roles/windows-executor/defaults/main/install_microsoft_tools_defaults.yml
+++ b/roles/windows-executor/defaults/main/install_microsoft_tools_defaults.yml
@@ -1,6 +1,6 @@
-dotnet_sdk_version_6: 6.0.403
+dotnet_sdk_version_6: 6.0.406
 sqlserver_devedition_version: 15.0.2000.5
-visualstudio_community_edition_version:  117.4.4.0
-visualstudio_buildtools_version: 117.4.4.0
-nuget_cli_version: 6.4.0
+visualstudio_community_edition_version:  117.5.0.0
+visualstudio_buildtools_version: 117.5.0.0
+nuget_cli_version: 6.5.0
 winappdriver_version: 1.2.1


### PR DESCRIPTION
The February image is going to be skipped (#169) so we're diving straight into March.