### PR TITLE
Refactor/setup and post tasks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,14 @@
+version: 2.1
+
+workflows:
+  main-wf:
+    jobs:
+      - check
+
+jobs:
+  check:
+    docker:
+      - image: cimg/deploy:2023.04
+    steps:
+      - run: |
+          echo "placeholder"

--- a/linux-playbook.yml
+++ b/linux-playbook.yml
@@ -25,3 +25,11 @@
     - dpkg_configure
   vars_files:
     - group_vars/linux_configure_vars.yml
+
+  post_tasks:
+    - name: Check if line is in file
+      become_method: sudo
+      become: true
+      ansible.builtin.lineinfile:
+        path: "{{ circleci_home }}/.bashrc"
+        line: if ! echo $- | grep -q "i" && [ -n "$BASH_ENV" ] && [ -f "$BASH_ENV" ]; then . "$BASH_ENV"; fi

--- a/roles/common/tasks/cci_specific.yml
+++ b/roles/common/tasks/cci_specific.yml
@@ -9,14 +9,6 @@
     - name: Redirect output (.bashrc)
       ansible.builtin.shell: echo 'source ~/.circlerc &>/dev/null' > '{{ circleci_home }}/.bashrc'
 
-    - name: check if line is in file
-      ansible.builtin.blockinfile:
-        path: "{{ circleci_home }}/.bashrc"
-        block:
-          source ~/.circlerc &>/dev/null
-          # if ! echo $- | grep -q "i" && [ -n "$BASH_ENV" ] && [ -f "$BASH_ENV" ]; then . "$BASH_ENV"; fi
-        create: yes
-
     - name: Change ownership of .bash_profile
       ansible.builtin.file:
         path: "{{ circleci_home }}/.bash_profile"

--- a/roles/common/tasks/system_prep.yml
+++ b/roles/common/tasks/system_prep.yml
@@ -60,8 +60,12 @@
     ansible.builtin.lineinfile:
       path: "/etc/sudoers.d/circleci"
       line: "circleci ALL=(ALL:ALL) NOPASSWD:ALL"
+      mode: 0400
       create: yes
 
+  - name: Reset connection so new user groups work
+    ansible.builtin.meta: reset_connection
+    
   become: true
 
   collections:


### PR DESCRIPTION
because BASH_ENV would be invoked (but doesn't exist) when the task is set in `cci_specific`, this is then used as a post task so that configuration files are not loaded, which would then break builds.

the reset connection task is also placed here to ensure the proper user groups are loaded once the ssh connection is re-established to ensure passwordless sudo

