### PR TITLE
chore: revert docker version to 20

### DIFF
--- a/manifest/software.json
+++ b/manifest/software.json
@@ -40,8 +40,8 @@
     "win_pyenv": "3.10.6"
   },
   "lein_version": "2.10.0",
-  "docker_version": "5:23.0.2-1~ubuntu.22.04~jammy",
-  "containerd_version": "1.6.19-1",
+  "docker_version": "5:20.10.24~3-0~ubuntu-jammy",
+  "containerd_version": "1.6.20-1",
   "docker_compose_version": "2.17.2-1~ubuntu.22.04~jammy",
   "gcloud_version": "424.0.0",
   "golang_version": "1.20.2",


### PR DESCRIPTION
because there are incompatibilities with the new Docker version 23, we need to revert back to 20.10.24