### PR TITLE
fix: flaky uid error

### DIFF
--- a/roles/system_prep/tasks/main.yml
+++ b/roles/system_prep/tasks/main.yml
@@ -34,13 +34,16 @@
       name: "{{ circleci_user }}"
       comment: CircleCI
       uid: 1001
+      non_unique: true
+      home: "{{ circleci_home }}"
+      move_home: true
       shell: /bin/bash
       group: "{{ circleci_user }}"
       groups: aws-sudoers,adm,audio,cdrom,dialout,dip,floppy,lxd,netdev,plugdev,video,ubuntu
       append: yes
       password: ''
       password_lock: yes
-  
+
   - name: Ensure .ssh directory exists for circleci user
     ansible.builtin.file:
       path: "{{ circleci_home }}/.ssh"


### PR DESCRIPTION
this used to be an issue, but was flaky when popping up. with this change, we should be able to associate the original uid, which exists as an aws/gcp uid/user to the circleci user