### PR TITLE
fix: uid process clashing crashes build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ workflows:
           run_build: true
           source_dirs: "manifest/software.json"
           zone: *gcp_zone
-          source_image: "ansible-ubuntu-2204-base-1684347129"
+          source_image: "ubuntu-2204-jammy-v20230616"
           image_name: linux-2204-test
           image_tag: *gcp_jammy_test_tag
           image_family: test-runs

--- a/linux-playbook-test.yml
+++ b/linux-playbook-test.yml
@@ -2,7 +2,7 @@
 - name: Configure linux node
   hosts: all
   roles:
-    # - common
+    - common
     # - gather_facts
     # - node
     # - java

--- a/roles/common/tasks/system_prep.yml
+++ b/roles/common/tasks/system_prep.yml
@@ -29,6 +29,22 @@
       gid: 1002
       non_unique: yes
 
+  - name: Register old user
+    become: true
+    ansible.builtin.shell: |
+      getent passwd "1001" | cut -d: -f1
+    register: old_user
+
+  - name: Set old user fact
+    ansible.builtin.set_fact:
+      oldUser: "{{ old_user.stdout }}"
+
+  - name: Remove uid 1001
+    ansible.builtin.user:
+      name: "{{ oldUser }}"
+      state: absent
+    when: "old_user.stdout != 'circleci'"
+
   - name: Ensure circleci user exists
     ansible.builtin.user:
       name: "{{ circleci_user }}"


### PR DESCRIPTION
uid clashing kills the build process, as the user being created is already in use.

an image was created with the same manifest using this [build](https://app.circleci.com/pipelines/github/CircleCI-Public/ansible/295/workflows/1b2e1ce2-1057-452b-8397-eca63976ed6a), but would start to fail in subsequent builds.

this [build](https://app.circleci.com/pipelines/github/CircleCI-Public/ansible/304/workflows/06d74c49-492b-40b6-b740-97723db10a8f) confirms we are able to rebuild without encountering a similar error

because gcp and aws have different default users, this accounts for both and only removes a user if the uid being replaced is not circleci, then sets the appropriate groups