### PR TITLE
fix ulimit defaults

### DIFF
--- a/roles/common/tasks/system_prep.yml
+++ b/roles/common/tasks/system_prep.yml
@@ -76,9 +76,11 @@
       create: yes
 
   - name: Ensure circleci user has passwordless sudo
-    ansible.builtin.lineinfile:
+    ansible.builtin.blockinfile:
       path: "/etc/sudoers.d/circleci"
-      line: "circleci ALL=(ALL:ALL) NOPASSWD:ALL"
+      block: |
+        circleci ALL=(ALL:ALL) NOPASSWD:ALL
+        Defaults rlimit_core=default
       mode: 0400
       create: yes
 


### PR DESCRIPTION
- changes in behavior for sudo [here](https://www.suse.com/support/kb/doc/?id=000020902) made it so the core dump size was set to 0. this PR fixes it by setting the option to it's defaults