### PR TITLE
utilize new nvm installer script

### DIFF
--- a/manifest/windows2022-software.json
+++ b/manifest/windows2022-software.json
@@ -22,7 +22,7 @@
   "rust_version": "1.68.0",
   "docker_version": "20.10.24",
   "docker_desktop_version": "4.19.0",
-  "nvm_version": "1.1.9",
+  "nvm_version": "1.1.11",
   "nodejs_dir": "C:\\Program Files\\nodejs",
   "dotnet_sdk_version_6": "6.0.412",
   "dotnet_sdk_version_7": "7.0.306",
@@ -34,6 +34,6 @@
   "package_state": "present",
   "syft_version": "0.84.1",
   "image_name": "windows-server-2022-gui",
-  "image_tag": "2023.07.1",
+  "image_tag": "2023.07.2",
   "image_group": "windows-server-2022"
 }

--- a/roles/windows/devtools/files/nvm-installer.ps1
+++ b/roles/windows/devtools/files/nvm-installer.ps1
@@ -1,0 +1,47 @@
+if( -not ( get-command Install-ChocolateyPackage -erroraction silentlycontinue ) ) {
+    Write-Host "Importing chocolateyInstaller.psm1..."
+    Import-Module C:\ProgramData\chocolatey\helpers\chocolateyInstaller.psm1
+}
+
+$ErrorActionPreference = "Stop"
+
+$packageName = 'nvm'
+$nodePath = "$env:SystemDrive\Program Files\nodejs"
+$nvmPath = Join-Path $env:ProgramData $packageName
+$NvmSettingsFile = Join-Path $nvmPath "settings.txt"
+
+if (Test-Path $nodePath) {
+    Remove-Item -Path $nodePath -Recurse -Force
+} else {
+    Write-Host "The path does not exist: $nodePath"
+}
+
+function install-nvm {
+    param($Version)
+    Invoke-WebRequest -UseBasicParsing "https://github.com/coreybutler/nvm-windows/releases/download/$Version/nvm-noinstall.zip" -o install-nvm.zip
+}
+
+install-nvm -Version $Version
+
+Expand-Archive -Path "install-nvm.zip" -DestinationPath $nvmPath -Force
+
+$NvmSettingsDict = [ordered]@{}
+if (Test-Path $NvmSettingsFile) {
+  $NvmSettings = Get-Content $NvmSettingsFile
+  $NvmSettings | Foreach-Object { $NvmSettingsDict.add($_.split(':', 2)[0], $_.split(':', 2)[1]) }
+  Write-Output "Detected existing settings file"
+  $NvmSettingsDict.GetEnumerator() | ForEach-Object { "$($_.Name): $($_.Value)" } | Write-Verbose
+}
+if (!($NvmSettingsDict['root'])) { $NvmSettingsDict['root'] = $nvmPath }
+if (!($NvmSettingsDict['path'])) { $NvmSettingsDict['path'] = $nodePath }
+if (!($NvmSettingsDict['arch'])) { $NvmSettingsDict['arch'] = $OsBits }
+if (!($NvmSettingsDict['proxy'])) { $NvmSettingsDict['proxy'] = "none" }
+
+$NvmSettingsDict.GetEnumerator() | ForEach-Object { "$($_.Name): $($_.Value)" } | Write-Verbose
+$NvmSettingsDict.GetEnumerator() | ForEach-Object { "$($_.Name): $($_.Value)" } | Out-File "$NvmSettingsFile" -Force -Encoding ascii
+
+Install-ChocolateyEnvironmentVariable -VariableName "NVM_HOME" -VariableValue "$nvmPath" -VariableType Machine;
+Install-ChocolateyEnvironmentVariable -VariableName "NVM_SYMLINK" -VariableValue "$nodePath" -VariableType Machine;
+
+Install-ChocolateyPath -PathToInstall "%NVM_HOME%" -PathType Machine;
+Install-ChocolateyPath -PathToInstall "%NVM_SYMLINK%" -PathType Machine;

--- a/roles/windows/devtools/tasks/main.yml
+++ b/roles/windows/devtools/tasks/main.yml
@@ -55,13 +55,6 @@
     version: '{{ miniconda3_version }}'
     force: yes
 
-- name: Install nodejs
-  win_chocolatey:
-    name: nodejs
-    state: '{{ package_state }}'
-    version: '{{ nodejs_version }}'
-    force: yes
-
 - name: Install ruby
   win_chocolatey:
     name: ruby
@@ -76,6 +69,21 @@
     version: '{{ rust_version }}'
     force: yes
 
+- name: Copy nvm-installer
+  ansible.windows.win_copy:
+    src: ../files/nvm-installer.ps1
+    dest: C:\nvm-installer.ps1
+
+- name: Run nvm-installer
+  ansible.windows.win_shell: |
+    $Version = "{{ nvm_version }}"
+    . C:\nvm-installer.ps1 -Version $Version
+
+- name: Install node
+  ansible.windows.win_shell: |
+    nvm install {{ nodejs_version }}
+    nvm use {{ nodejs_version }}
+
 - name: Install docker engine
   win_chocolatey:
     name: docker-engine
@@ -83,18 +91,6 @@
     state: '{{ package_state }}'
     version: '{{ docker_version }}'
     force: yes
-
-- name: Install nvm.portable
-  win_chocolatey:
-    name: nvm.portable
-    state: '{{ package_state }}'
-    version: '{{ nvm_version }}'
-    force: yes
-
-- name: Remove nodejs directory due to nvm issues
-  ansible.windows.win_file:
-    path: '{{ nodejs_dir }}'
-    state: absent
 
 - name: Install docker with new script
   ansible.windows.win_powershell:

--- a/scripts/nvm-installer.ps1
+++ b/scripts/nvm-installer.ps1
@@ -1,0 +1,42 @@
+if( -not ( get-command Install-ChocolateyPackage -erroraction silentlycontinue ) ) {
+    Write-Host "Importing chocolateyInstaller.psm1..."
+    Import-Module C:\ProgramData\chocolatey\helpers\chocolateyInstaller.psm1 #-Verbose
+}
+
+$ErrorActionPreference = "Stop"
+
+$packageName = 'nvm'
+$nodePath = "$env:SystemDrive\Program Files\nodejs"
+$nvmPath = Join-Path $env:ProgramData $packageName
+$NvmSettingsFile = Join-Path $nvmPath "settings.txt"
+
+if (Test-Path $nodePath) {
+    Remove-Item -Path $nodePath -Recurse -Force
+} else {
+    Write-Host "The path does not exist: $nodePath"
+}
+
+Invoke-WebRequest -UseBasicParsing "https://github.com/coreybutler/nvm-windows/releases/download/1.1.11/nvm-noinstall.zip" -o install-nvm.zip
+
+Expand-Archive -Path "install-nvm.zip" -DestinationPath $nvmPath
+
+$NvmSettingsDict = [ordered]@{}
+if (Test-Path $NvmSettingsFile) {
+  $NvmSettings = Get-Content $NvmSettingsFile
+  $NvmSettings | Foreach-Object { $NvmSettingsDict.add($_.split(':', 2)[0], $_.split(':', 2)[1]) }
+  Write-Output "Detected existing settings file"
+  $NvmSettingsDict.GetEnumerator() | ForEach-Object { "$($_.Name): $($_.Value)" } | Write-Verbose
+}
+if (!($NvmSettingsDict['root'])) { $NvmSettingsDict['root'] = $nvmPath }
+if (!($NvmSettingsDict['path'])) { $NvmSettingsDict['path'] = $nodePath }
+if (!($NvmSettingsDict['arch'])) { $NvmSettingsDict['arch'] = $OsBits }
+if (!($NvmSettingsDict['proxy'])) { $NvmSettingsDict['proxy'] = "none" }
+
+$NvmSettingsDict.GetEnumerator() | ForEach-Object { "$($_.Name): $($_.Value)" } | Write-Verbose
+$NvmSettingsDict.GetEnumerator() | ForEach-Object { "$($_.Name): $($_.Value)" } | Out-File "$NvmSettingsFile" -Force -Encoding ascii
+
+Install-ChocolateyEnvironmentVariable -VariableName "NVM_HOME" -VariableValue "$nvmPath" -VariableType Machine;
+Install-ChocolateyEnvironmentVariable -VariableName "NVM_SYMLINK" -VariableValue "$nodePath" -VariableType Machine;
+
+Install-ChocolateyPath -PathToInstall "%NVM_HOME%" -PathType Machine;
+Install-ChocolateyPath -PathToInstall "%NVM_SYMLINK%" -PathType Machine;


### PR DESCRIPTION
- chocolatey was installing `nvm.portable`, which was set at a version of 1.1.9. the current version of nvm-windows is 1.1.11
- chocolatey was also installing nodejs 20.4.0, but this version was inaccessible despite being listed by chocolatey
- the `nvm` and `nvm.install` packages point to the correct version of nvm, however, the installation method is not suitable for an automated build
- because we do not want to be reliant on others updating a package, especially when it hasn't been updated in over a year, this PR aims to solve that by with a script that downloads from the source, unpacks, and allows us directly control which version we need
- this PR also allows us to download the most current versions of node e.g 20.4.0. This would close #203 