### PR TITLE
Refactor/win user fix

### DIFF
--- a/roles/windows/common/tasks/main.yml
+++ b/roles/windows/common/tasks/main.yml
@@ -5,8 +5,8 @@
 - name: Disable windows services
   include_tasks: 'roles/windows/disable_services/tasks/main.yml'
 
-- name: Create CircleCI users
-  include_tasks: 'roles/windows/create_users/tasks/main.yml'
+# - name: Create CircleCI users
+#   include_tasks: 'roles/windows/create_users/tasks/main.yml'
 
 - name: install Build Agent Prerequisites
   include_tasks: 'roles/windows/buildagent_prereq/tasks/main.yml'

--- a/roles/windows/common/tasks/main.yml
+++ b/roles/windows/common/tasks/main.yml
@@ -5,8 +5,5 @@
 - name: Disable windows services
   include_tasks: 'roles/windows/disable_services/tasks/main.yml'
 
-# - name: Create CircleCI users
-#   include_tasks: 'roles/windows/create_users/tasks/main.yml'
-
 - name: install Build Agent Prerequisites
   include_tasks: 'roles/windows/buildagent_prereq/tasks/main.yml'

--- a/windows-playbook.yml
+++ b/windows-playbook.yml
@@ -3,10 +3,28 @@
   hosts: default
   connection: local
   roles:
-    - windows/common
-    - windows/install_cloudtools
-    - windows/devtools
-    - windows/microsoft_tools
-    - windows/syft
+    - role: windows/create_users
+      tags:
+        - 'create_users'
+    - role: windows/common
+      tags:
+        - 'common'
+        - 'build'
+    - role: windows/install_cloudtools
+      tags:
+        - 'cloudtools'
+        - 'build'
+    - role: windows/devtools
+      tags:
+        - 'devtools'
+        - 'build'
+    - role: windows/microsoft_tools
+      tags:
+        - 'ms_tools'
+        - 'build'
+    - role: windows/syft
+      tags:
+        - 'syft'
+        - 'build'
   vars_files:
     - group_vars/windows_configure_vars.yml


### PR DESCRIPTION
this breaks out the build by tags for now so that the build can be completed in stages. specifically, we would want one user, with permissions, to create users and add them to appropriate groups. the second stage should allow us to build using that created user with appropriate credentials

- a separate PR will need to be created that adds the a second provision step