### PR TITLE
Refactor/yaml manifest

### DIFF
--- a/roles/awscli/tasks/main.yml
+++ b/roles/awscli/tasks/main.yml
@@ -1,15 +1,13 @@
 ---
 - block:
     - name: Download awscli (arm64)
-      ansible.builtin.get_url:
-        url: "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip"
-        dest: '/tmp/awscliv2.zip'
+      ansible.builtin.shell: |
+        curl -fsSL -o /tmp/awscliv2.zip https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip
       when: arch == "arm64" or arch == "aarch64"
 
     - name: Download awscli (amd64)
-      ansible.builtin.get_url:
-        url: "https://awscli.amazonaws.com/awscli-exe-linux-{{ ansible_facts.architecture }}.zip"
-        dest: '/tmp/awscliv2.zip'
+      ansible.builtin.shell: |
+        curl -fsSL -o /tmp/awscliv2.zip https://awscli.amazonaws.com/awscli-exe-linux-{{ ansible_facts.architecture }}.zip
       when: arch == "amd64" or arch == "x86_64"
 
     - name: Extract awscli

--- a/roles/chrome/tasks/main.yml
+++ b/roles/chrome/tasks/main.yml
@@ -1,15 +1,10 @@
 ---
 - block:
   - name: Add APT signing key for linux chrome
-    ansible.builtin.apt_key:
-      url: "https://dl-ssl.google.com/linux/linux_signing_key.pub"
-      state: present
-
-  - name: Add download link for debian chrome to source list
-    ansible.builtin.lineinfile:
-      path: "/etc/apt/sources.list.d/google-chrome.list"
-      line: "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main"
-      create: yes
+    become_method: sudo
+    ansible.builtin.shell: |
+      curl -fsSL https://dl.google.com/linux/linux_signing_key.pub | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/chrome.gpg
+      echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee -a /etc/apt/sources.list.d/google.list
 
   - name: Install google chrome
     ansible.builtin.apt:

--- a/roles/clojure/tasks/main.yml
+++ b/roles/clojure/tasks/main.yml
@@ -1,9 +1,8 @@
 ---
 - block:
     - name: Download clojure
-      ansible.builtin.get_url:
-        url: "https://raw.github.com/technomancy/leiningen/{{ lein_version }}/bin/lein"
-        dest: "{{ lein_dir }}"
+      ansible.builtin.shell: |
+        sudo curl -sSL -o /usr/local/bin/lein https://raw.github.com/technomancy/leiningen/{{ lein_version }}/bin/lein --create-dirs
 
     - name: Change permissions on /usr/local/bin/lein
       ansible.builtin.file:

--- a/roles/gcloud/tasks/main.yml
+++ b/roles/gcloud/tasks/main.yml
@@ -8,15 +8,13 @@
         state: directory
 
     - name: Download gcloud (arm64)
-      ansible.builtin.get_url:
-        url: "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-{{ gcloud_version }}-linux-arm.tar.gz"
-        dest: "/tmp/gcloud.tar.gz"
+      ansible.builtin.shell: |
+        curl -fsSL -o /tmp/gcloud.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-{{ gcloud_version }}-linux-arm.tar.gz
       when: arch == "arm64" or arch == "aarch64"
 
     - name: Download gcloud (amd64)
-      ansible.builtin.get_url:
-        url: "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-{{ gcloud_version }}-linux-{{ ansible_facts.architecture }}.tar.gz"
-        dest: "/tmp/gcloud.tar.gz"
+      ansible.builtin.shell: |
+        curl -fsSL -o /tmp/gcloud.tar.gz https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-{{ gcloud_version }}-linux-{{ ansible_facts.architecture }}.tar.gz
       when: arch == "amd64" or arch == "x86_64"
 
     - name: Extract gcloud

--- a/roles/golang/tasks/main.yml
+++ b/roles/golang/tasks/main.yml
@@ -1,9 +1,8 @@
 ---
 - block:
     - name: Download golang
-      ansible.builtin.get_url:
-        url: "http://golang.org/dl/go{{ golang_version }}.linux-{{ arch }}.tar.gz"
-        dest: "/tmp/golang.tar.gz"
+      ansible.builtin.shell: |
+        curl -sSL -o /tmp/golang.tar.gz http://golang.org/dl/go{{ go_version }}.linux-{{ arch }}.tar.gz
 
     - name: Extract golang
       ansible.builtin.unarchive:

--- a/roles/java/vars/main.yml
+++ b/roles/java/vars/main.yml
@@ -1,3 +1,6 @@
 ---
 circleci_user: circleci
 circleci_home: /home/circleci
+java_versions:
+  - "{{ java8_version }}"
+  - "{{ java17_version }}"

--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -66,7 +66,7 @@
     - name: Set Node defaults
       become_method: sudo
       ansible.builtin.shell:
-        sudo -H -i -u {{ circleci_user }} /bin/bash -c "source /home/circleci/.circlerc nvm alias default {{ defaults.node }} && nvm use {{ defaults.node }}"
+        sudo -H -i -u {{ circleci_user }} /bin/bash -c "source /home/circleci/.circlerc nvm alias default {{ nodelts_version }} && nvm use {{ nodelts_version }}"
 
     - name: Install npm packages
       become_method: sudo

--- a/roles/node/vars/main.yml
+++ b/roles/node/vars/main.yml
@@ -2,3 +2,6 @@
 circleci_user: circleci
 circleci_home: /home/circleci
 nvm_dir: '/opt/{{ circleci_user }}/.nvm'
+node:
+  - "{{ nodelts_version }}"
+  - "{{ nodeCurrent_version }}"

--- a/roles/python3/vars/main.yml
+++ b/roles/python3/vars/main.yml
@@ -2,3 +2,6 @@
 circleci_user: circleci
 circleci_home: /home/circleci
 pyenv_dir: "/opt/circleci/.pyenv"
+python_versions:
+  - "{{ python2_version }}"
+  - "{{ python3_version }}"

--- a/roles/ruby/tasks/main.yml
+++ b/roles/ruby/tasks/main.yml
@@ -51,6 +51,6 @@
 
     - name: Install ruby and set as global
       ansible.builtin.shell:
-        sudo -H -i -u {{ circleci_user }} /bin/bash -c "source /home/circleci/.circlerc && rbenv install {{ defaults.ruby }} && rbenv global {{ defaults.ruby }}"
+        sudo -H -i -u {{ circleci_user }} /bin/bash -c "source /home/circleci/.circlerc && rbenv install {{ ruby_version }} && rbenv global {{ ruby_version }}"
 
   become: true

--- a/roles/yq/tasks/main.yml
+++ b/roles/yq/tasks/main.yml
@@ -2,7 +2,7 @@
 - block:
     - name: Download yq
       ansible.builtin.get_url:
-        url: "https://github.com/mikefarah/yq/releases/download/v{{ yq }}/yq_linux_{{ arch }}.tar.gz"
+        url: "https://github.com/mikefarah/yq/releases/download/v{{ yq_version }}/yq_linux_{{ arch }}.tar.gz"
         dest: "/tmp/yq.tar.gz"
 
     - name: Create /tmp/yq directory

--- a/roles/yq/tasks/main.yml
+++ b/roles/yq/tasks/main.yml
@@ -1,9 +1,8 @@
 ---
 - block:
     - name: Download yq
-      ansible.builtin.get_url:
-        url: "https://github.com/mikefarah/yq/releases/download/v{{ yq_version }}/yq_linux_{{ arch }}.tar.gz"
-        dest: "/tmp/yq.tar.gz"
+      ansible.builtin.shell: |
+        curl -fsSL -o /tmp/yq.tar.gz https://github.com/mikefarah/yq/releases/download/v{{ yq_version }}/yq_linux_{{ arch }}.tar.gz
 
     - name: Create /tmp/yq directory
       ansible.builtin.file:


### PR DESCRIPTION
- a couple of changes here to account for the yml manifest
- needed to fix google's signing key to download chrome
- python 3.12 removed a lot of things e.g `cert_file` that broke installations when using the ansible `get_url` module. as a result, this was migrated over to using shell and curl 
