### PR TITLE
[PROV-438] fix default python versions

### DIFF
--- a/roles/python3/tasks/main.yml
+++ b/roles/python3/tasks/main.yml
@@ -55,7 +55,7 @@
     - name: Set Pyenv global
       become_method: sudo
       ansible.builtin.shell:
-        "sudo -H -i -u {{ circleci_user }} {{ pyenv_dir }}/bin/pyenv global {{ python2_version }} {{ python3_version }}"
+        "sudo -H -i -u {{ circleci_user }} {{ pyenv_dir }}/bin/pyenv global {{ python3_version }} {{ python2_version }}"
 
     - name: Install Pip Packages
       become_method: sudo


### PR DESCRIPTION
just switching the order of the `pyenv global` command so that python 3+ is the default rather than python 2