### PR TITLE
fix: remove shell inits

### DIFF
--- a/linux-playbook.yml
+++ b/linux-playbook.yml
@@ -8,7 +8,6 @@
     - java
     - python3
     - ruby
-    # - firefox
     - chrome
     - docker
     - sysadmin_tools

--- a/roles/python3/tasks/main.yml
+++ b/roles/python3/tasks/main.yml
@@ -43,8 +43,6 @@
           export PYENV_ROOT="{{ pyenv_dir }}"
           export PATH=$PYENV_ROOT/bin:$PATH
           export PATH=$PYENV_ROOT/shims:$PATH
-          eval "$(pyenv init --path)"
-          eval "$(pyenv init -)"
 
     - name: Install Python
       become_method: sudo

--- a/roles/ruby/tasks/main.yml
+++ b/roles/ruby/tasks/main.yml
@@ -24,7 +24,6 @@
         marker_end: "RUBY END"
         block: |
           export PATH="{{ ruby_dir }}/bin:$PATH"
-          eval "$(rbenv init -)"
     - name: Configure .gemrc
       ansible.builtin.blockinfile:
         path: "{{ gemrc_file }}"


### PR DESCRIPTION
shell inits in `~/.circlerc`, which is sourced by `~/.bashrc` when circleci runs, breaks the shell/PATH when `$BASH_ENV` [sets the PATH](https://github.com/rbenv/rbenv/issues/1398)

e.g `echo "export PATH=hello/there:$PATH" >> "$BASH_ENV"`. While setting this will still break the functionality of pyenv and rbenv, it will not completely break the shell as we are not initializing `pyenv` and `rbenv`on every step

Two workarounds for this are to:
- set the modified path in `~/.circlerc`, which will achieve the same effect of persisting modifications to the PATH similar to `$BASH_ENV`
- Remove the PATH modifications in `$BASH_ENV` e.g `echo "export "" >> "$BASH_ENV""`. This would only affect people who end up using `pyenv` or `rbenv`