### PR TITLE
fix fastlane for android

### DIFF
--- a/roles/android_tools/tasks/main.yml
+++ b/roles/android_tools/tasks/main.yml
@@ -20,4 +20,4 @@
 
 - name: Install fastlane
   ansible.builtin.shell: |
-    rbenv exec gem install fastlane --version {{ fastlane_version }} --no-document
+    sudo gem install fastlane --version {{ fastlane_version }} --no-document


### PR DESCRIPTION
fastlane has been broken in trying to install it on recent builds for android changing to this seems to have fixed the issue and tests seem to validate with this change that it is working again. Tested this out through: https://app.circleci.com/pipelines/github/CircleCI-Public/android-machine/165/workflows/4ea53ec8-c1d0-40ff-a120-ccb84913fcf0/jobs/920
https://github.com/CircleCI-Public/android-machine/commit/f944ae664137a5bff0596e0503d98067a00cc763