### PR TITLE
Reject kb 2267602

### DIFF
--- a/roles/windows/microsoft_tools/tasks/main.yml
+++ b/roles/windows/microsoft_tools/tasks/main.yml
@@ -65,7 +65,7 @@
   win_chocolatey:
     name: visualstudio2019community
     state: '{{ package_state }}'
-    package_params: '--allWorkloads --includeRecommended --includeOptional --quiet --locale en-US'
+    package_params: '--allWorkloads --remove Microsoft.VisualStudio.Component.Azure.Storage.AzCopy --includeRecommended --includeOptional --quiet --locale en-US'
     timeout: 12000
     version: '{{ visualstudio_community_edition_version }}'
     force: yes

--- a/roles/windows/microsoft_tools/tasks/main.yml
+++ b/roles/windows/microsoft_tools/tasks/main.yml
@@ -75,7 +75,7 @@
   win_chocolatey:
     name: visualstudio2019buildtools
     state: '{{ package_state }}'
-    package_params: '--allWorkloads --includeRecommended --includeOptional --quiet --locale en-US'
+    package_params: '--allWorkloads --remove Microsoft.VisualStudio.Component.Azure.Storage.AzCopy --includeRecommended --includeOptional --quiet --locale en-US'
     version: '{{ visualstudio_buildtools_version }}'
     force: yes
   when: '"OS Name:                   Microsoft Windows Server 2019 Datacenter" in win_version.output'

--- a/roles/windows/windows_updates/tasks/main.yml
+++ b/roles/windows/windows_updates/tasks/main.yml
@@ -7,4 +7,5 @@
       - 5019081
       - 4052623
       - 5034439
+      - 2267602 # (maybe) causing an update loop
     skip_optional: true


### PR DESCRIPTION
Corrected issues with `Windows-2019-Machine` build ([example](https://app.circleci.com/pipelines/github/CircleCI-Public/Win-2019-Machine/415/workflows/6cfc224c-b213-485e-a1a5-610086b687bd/jobs/1148)).