### PR TITLE
Add Windows NVIDIA support role and playbook

### DIFF
--- a/roles/windows/nvidia/tasks/main.yml
+++ b/roles/windows/nvidia/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+- name: Install NVIDIA Display Driver
+  win_chocolatey:
+    name: nvidia-display-driver
+    state: '{{ package_state }}'
+    force: true
+
+- name: Install CUDA Toolkit
+  win_chocolatey:
+    name: cuda
+    state: '{{ package_state }}'
+    version: '{{ cuda_version }}'
+    force: true
+
+- name: Verify NVIDIA Installation
+  ansible.windows.win_command:
+    cmd: nvidia-smi
+  register: nvidia_check

--- a/roles/windows/nvidia/vars/main.yml
+++ b/roles/windows/nvidia/vars/main.yml
@@ -1,0 +1,3 @@
+---
+package_state: present
+cuda_version: "12.7"

--- a/windows-nvidia-playbook.yml
+++ b/windows-nvidia-playbook.yml
@@ -1,0 +1,35 @@
+---
+- name: Configure windows node with NVIDIA support
+  hosts: default
+  connection: local
+  roles:
+    - role: windows/create_users
+      tags:
+        - 'create_users'
+    - role: windows/common
+      tags:
+        - 'common'
+        - 'build'
+    - role: windows/install_cloudtools
+      tags:
+        - 'cloudtools'
+        - 'build'
+    - role: windows/devtools
+      tags:
+        - 'devtools'
+        - 'build'
+    - role: windows/microsoft_tools
+      tags:
+        - 'ms_tools'
+        - 'build'
+    - role: windows/nvidia
+      tags:
+        - 'nvidia'
+        - 'build'
+    - role: windows/syft
+      tags:
+        - 'syft'
+        - 'build'
+      when: '"OS Name:                   Microsoft Windows Server 2022 Datacenter" in win_version.output'
+  vars_files:
+    - group_vars/windows_configure_vars.yml


### PR DESCRIPTION
Add NVIDIA GPU support for Windows machines

This will help with the new `windows-2022-nvidia-medium` builds