### PR TITLE
Update default cuda version for  Windows 2022 Nvidia Image

### DIFF
--- a/roles/windows/nvidia/vars/main.yml
+++ b/roles/windows/nvidia/vars/main.yml
@@ -1,3 +1,3 @@
 ---
 package_state: present
-cuda_version: "12.7"
+cuda_version: "12.8.0.571"


### PR DESCRIPTION
Set default cuda version to `12.8.0.571` since 12.7 is not available. Note: Cuda gets overriden in the WIn-2022 image