### PR TITLE
Update maven download source

### DIFF
--- a/roles/java/tasks/main.yml
+++ b/roles/java/tasks/main.yml
@@ -37,7 +37,7 @@
 - block:
   - name: Download maven
     ansible.builtin.get_url:
-      url: "http://apache.osuosl.org/maven/maven-3/{{maven_version}}/binaries/apache-maven-{{maven_version}}-bin.tar.gz"
+      url: "https://archive.apache.org/dist/maven/maven-3/{{maven_version}}/binaries/apache-maven-{{maven_version}}-bin.tar.gz"
       dest: "/tmp/maven.tar.gz"
 
   - name: Extract maven


### PR DESCRIPTION
This `http://apache.osuosl.org/maven/maven-3/{{maven_version}}/binaries/apache-maven-{{maven_version}}-bin.tar.gz` is no longer a reliable source, https://osuosl.org/blog/osl-future/

Maven download is now made via the official distribution via `https://archive.apache.org`