### PR TITLE
Fix user modification error in system prep

### DIFF
--- a/roles/common/tasks/system_prep.yml
+++ b/roles/common/tasks/system_prep.yml
@@ -45,6 +45,13 @@
       state: absent
     when: "old_user.stdout != 'circleci'"
 
+  - name: Check if circleci user exists with correct properties
+    ansible.builtin.shell: |
+      getent passwd circleci | grep -q ":1001:"
+    register: circleci_user_check
+    ignore_errors: true
+    changed_when: false
+
   - name: Ensure circleci user exists
     ansible.builtin.user:
       name: "{{ circleci_user }}"
@@ -60,6 +67,7 @@
       password: ''
       password_lock: yes
       state: present
+    when: circleci_user_check.rc != 0
 
   - name: Ensure .ssh directory exists for circleci user
     ansible.builtin.file:


### PR DESCRIPTION
Fixed Ansible playbook failure by adding a conditional check before modifying the circleci user account, preventing the "user currently used by process" error that occurred when the playbook tried to modify the same user that was running it.