### PR TITLE
Remove IncrediBuild installation for windows machines

### DIFF
--- a/roles/windows/microsoft_tools/tasks/main.yml
+++ b/roles/windows/microsoft_tools/tasks/main.yml
@@ -40,7 +40,7 @@
   win_chocolatey:
     name: visualstudio2022community
     state: '{{ package_state }}'
-    package_params: '--allWorkloads --includeRecommended --includeOptional --quiet --locale en-US'
+    package_params: '--allWorkloads --remove Microsoft.VisualStudio.Component.IncrediBuild --includeRecommended --includeOptional --quiet --locale en-US'
     timeout: 5400
     version: '{{ visualstudio_community_edition_version }}'
     force: yes
@@ -50,7 +50,7 @@
   win_chocolatey:
     name: visualstudio2022buildtools
     state: '{{ package_state }}'
-    package_params: '--allWorkloads --includeRecommended --includeOptional --quiet --locale en-US'
+    package_params: '--allWorkloads --remove Microsoft.VisualStudio.Component.IncrediBuild --includeRecommended --includeOptional --quiet --locale en-US'
     version: '{{ visualstudio_buildtools_version }}'
     force: yes
   when: '"OS Name:                   Microsoft Windows Server 2022 Datacenter" in win_version.output'
@@ -65,7 +65,7 @@
   win_chocolatey:
     name: visualstudio2019community
     state: '{{ package_state }}'
-    package_params: '--allWorkloads --remove Microsoft.VisualStudio.Component.Azure.Storage.AzCopy --includeRecommended --includeOptional --quiet --locale en-US'
+    package_params: '--allWorkloads --remove Microsoft.VisualStudio.Component.Azure.Storage.AzCopy --remove Microsoft.VisualStudio.Component.IncrediBuild --includeRecommended --includeOptional --quiet --locale en-US'
     timeout: 12000
     version: '{{ visualstudio_community_edition_version }}'
     force: yes
@@ -75,7 +75,7 @@
   win_chocolatey:
     name: visualstudio2019buildtools
     state: '{{ package_state }}'
-    package_params: '--allWorkloads --remove Microsoft.VisualStudio.Component.Azure.Storage.AzCopy --includeRecommended --includeOptional --quiet --locale en-US'
+    package_params: '--allWorkloads --remove Microsoft.VisualStudio.Component.Azure.Storage.AzCopy --remove Microsoft.VisualStudio.Component.IncrediBuild --includeRecommended --includeOptional --quiet --locale en-US'
     version: '{{ visualstudio_buildtools_version }}'
     force: yes
   when: '"OS Name:                   Microsoft Windows Server 2019 Datacenter" in win_version.output'


### PR DESCRIPTION
## Problem

`IncrediBuild` is being automatically installed as part of Visual Studio workloads in our Windows Server 2022 images. This tool starts a service that binds to port 8000, causing conflicts when customers try to run applications on the same port. This results in bind errors and prevents applications from starting.

## Cause

Visual Studio installations use --allWorkloads --includeRecommended --includeOptional which includes all available components, including `IncrediBuild`. The `Microsoft.VisualStudio.Component.IncrediBuild` component is installed by default and automatically starts services that use port 8000.

## Solution

Modified Visual Studio installation parameters in `roles/windows/microsoft_tools/tasks/main.yml` to explicitly exclude the IncrediBuild component.
