### PR TITLE
[NOTICKET] Resolve stderr newline issue in clojure role

### DIFF
--- a/roles/clojure/tasks/main.yml
+++ b/roles/clojure/tasks/main.yml
@@ -3,6 +3,8 @@
     - name: Download clojure
       ansible.builtin.shell: |
         sudo curl -sSL -o /usr/local/bin/lein https://raw.github.com/technomancy/leiningen/{{ lein_version }}/bin/lein --create-dirs
+      args:
+        stdin_add_newline: false
 
     - name: Change permissions on /usr/local/bin/lein
       ansible.builtin.file:
@@ -13,5 +15,7 @@
 
     - name: Force lein dependencies to download
       ansible.builtin.shell: lein -v
+      args:
+        stdin_add_newline: false
 
   become: true


### PR DESCRIPTION
This PR fixes the stderr newline issue in the Clojure role by adding stdin_add_newline: false to shell commands, preventing Ansible from automatically adding newlines that were causing Packer build errors.