### PR TITLE
[NOTICKET] Fix clojure role: replace raw.github.com with raw.githubusercontent.com

### DIFF
--- a/roles/clojure/tasks/main.yml
+++ b/roles/clojure/tasks/main.yml
@@ -2,7 +2,7 @@
 - block:
     - name: Download clojure
       ansible.builtin.shell: |
-        sudo curl -sSL -o /usr/local/bin/lein https://raw.github.com/technomancy/leiningen/{{ lein_version }}/bin/lein --create-dirs
+        sudo curl -sSL -o /usr/local/bin/lein https://raw.githubusercontent.com/technomancy/leiningen/{{ lein_version }}/bin/lein --create-dirs
       args:
         stdin_add_newline: false
 


### PR DESCRIPTION
This PR fixes a 503 error in the clojure role by updating the leiningen download URL from raw.github.com to raw.githubusercontent.com. 