### PR TITLE
Fix Maven download certificate validation issue

### DIFF
--- a/roles/java/tasks/main.yml
+++ b/roles/java/tasks/main.yml
@@ -39,6 +39,8 @@
     ansible.builtin.get_url:
       url: "https://archive.apache.org/dist/maven/maven-3/{{maven_version}}/binaries/apache-maven-{{maven_version}}-bin.tar.gz"
       dest: "/tmp/maven.tar.gz"
+      validate_certs: no
+      timeout: 30
 
   - name: Extract maven
     ansible.builtin.unarchive:


### PR DESCRIPTION
# Fix Maven Download Certificate Validation Issue

## Problem
The Maven download task in the Java role was failing due to SSL certificate validation issues when downloading from Apache Maven archives. This was causing build failures during Packer image creation.

## Root Cause
- SSL certificate validation was failing when downloading Maven from `https://archive.apache.org/dist/maven/`
- The download task was hanging or failing due to certificate chain validation problems