### PR TITLE
skip KB5070881 windows update due to reboot loop

### DIFF
--- a/roles/windows/windows_updates/tasks/main.yml
+++ b/roles/windows/windows_updates/tasks/main.yml
@@ -9,4 +9,5 @@
       - 5034439
       - 2267602 # (maybe) causing an update loop
       - 890830 # (maybe) causing an update loop
+      - 5070881 # (maybe) causing an update loop
     skip_optional: true


### PR DESCRIPTION
KB5070881 is causing reboot loops. Skipping it should resolve the issue.