### PR TITLE
Use circleci-admin instead of default Administrator user for dotnetfx installation

### DIFF
--- a/roles/windows/microsoft_tools/tasks/main.yml
+++ b/roles/windows/microsoft_tools/tasks/main.yml
@@ -40,11 +40,12 @@
     name: dotnetfx
     state: '{{ package_state }}'
     timeout: 5400
-    force: yes
   when: '"OS Name:                   Microsoft Windows Server 2022 Datacenter" in win_version.output'
-  become: true
-  become_user: Administrator
-  become_method: runas
+  vars:
+    ansible_become: true
+    ansible_become_method: runas
+    ansible_become_user: circleci-admin
+    ansible_become_password: '{{ cci_admin_pwd }}'
 
 - name: Install vcredist 140
   ansible.windows.win_powershell:


### PR DESCRIPTION
GCP disables the `Administrator` account on Windows VMs, while AWS permits it. In order to install `dotnetfx` with elevated access, we should instead use the `circleci-admin` user, which has Administrator privileges. 