### PR TITLE
Skip git-core PPA on Ubuntu 26.04

### DIFF
--- a/roles/common/tasks/base.yml
+++ b/roles/common/tasks/base.yml
@@ -45,7 +45,7 @@
     - name: Add git-core repository from PPA
       ansible.builtin.apt_repository:
         repo: ppa:git-core/ppa
-      when: ansible_facts['distribution_major_version'] != "24" # git-core/ppa does not install on 24.04
+      when: ansible_facts['distribution_major_version'] not in ["24", "26"] # git-core/ppa does not install on 24.04+
 
     - name: Install core packages
       ansible.builtin.apt:


### PR DESCRIPTION
Excludes Ubuntu 26.04 from the git-core PPA installation task, which does not support 24.04+.