### PR TITLE
Skip rlimit_core sudoers setting on Ubuntu 26.04

### DIFF
--- a/roles/common/tasks/system_prep.yml
+++ b/roles/common/tasks/system_prep.yml
@@ -97,7 +97,7 @@
       line: Defaults rlimit_core=default
       mode: 0440
       create: yes
-    when: ansible_facts['distribution_major_version'] != "20"
+    when: ansible_facts['distribution_major_version'] not in ["20", "26"]
 
   - name: Test sudoers files
     ansible.builtin.shell:


### PR DESCRIPTION
Ubuntu 26.04 ships a sudo version that no longer supports rlimit_core.