### PR TITLE
Install versioned kernel modules package on Ubuntu 26.04 GCP builds

### DIFF
--- a/roles/common/tasks/base.yml
+++ b/roles/common/tasks/base.yml
@@ -94,6 +94,16 @@
           - linux-modules-extra-gcp
       when:
         - system_uuid.stdout != "ec2*" or system_uuid.stdout != "EC2*"
+        - ansible_facts['distribution_major_version'] != "26"
+
+    # linux-modules-extra-gcp metapackage is not published for Ubuntu 26.04;
+    # install the versioned kernel-specific package directly instead.
+    - name: Ensure extra GCP modules are installed (26.04)
+      ansible.builtin.shell: |
+        apt-get install -y linux-modules-extra-$(uname -r)
+      when:
+        - system_uuid.stdout != "ec2*" or system_uuid.stdout != "EC2*"
+        - ansible_facts['distribution_major_version'] == "26"
 
     - name: Configure ulimit
       ansible.builtin.blockinfile:


### PR DESCRIPTION
linux-modules-extra-gcp metapackage is not published for Ubuntu 26.04; use linux-modules-extra-$(uname -r) directly for 26.04 GCP instances instead.