### PR TITLE
Ignore missing linux-modules-extra-gcp on Ubuntu 26.04

### DIFF
--- a/roles/common/tasks/base.yml
+++ b/roles/common/tasks/base.yml
@@ -88,21 +88,14 @@
       when:
         - system_uuid.stdout == "ec2*" or system_uuid.stdout == "EC2*"
 
+    # linux-modules-extra-gcp is not published for Ubuntu 26.04; ignore failure on that release.
     - name: Ensure extra GCP modules are installed
       ansible.builtin.apt:
         pkg:
           - linux-modules-extra-gcp
+      ignore_errors: true
       when:
         - system_uuid.stdout != "ec2*" or system_uuid.stdout != "EC2*"
-        - ansible_facts['distribution_major_version'] != "26"
-
-    # linux-modules-extra-gcp metapackage is not published for Ubuntu 26.04;
-    # install the versioned kernel-specific package directly instead.
-    - name: Ensure extra GCP modules are installed (26.04)
-      ansible.builtin.shell: apt-get install -y linux-modules-extra-$(uname -r)
-      when:
-        - system_uuid.stdout != "ec2*" or system_uuid.stdout != "EC2*"
-        - ansible_facts['distribution_major_version'] == "26"
 
     - name: Configure ulimit
       ansible.builtin.blockinfile:


### PR DESCRIPTION
The `linux-modules-extra-gcp` package is not published in Ubuntu 26.04 repos. On 26.04, the GCP base image already ships with the necessary GCP hardware drivers (gvnic, virtio), so this package is not needed.

Adding `ignore_errors: true` allows the build to continue on 26.04 without failing. 