### PR TITLE
Update kernel module installation logic…

### DIFF
--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -75,8 +75,8 @@
 
     - name: Grab uuid for extra kernel modules
       ansible.builtin.shell: |
-        dmidecode --string system-uuid
-      register: system_uuid
+        dmidecode --string bios-vendor
+      register: system_vendor
       ignore_errors: true
 
     - name: Ensure extra AWS modules are installed
@@ -84,14 +84,14 @@
         pkg:
           - linux-modules-extra-aws
       when: 
-        - system_uuid.stdout == "ec2*" or system_uuid.stdout == "EC2*"
+        - system_vendor.stdout == "Amazon EC2" or system_vendor.stdout == "Vultr"
 
     - name: Ensure extra GCP modules are installed
       ansible.builtin.apt:
         pkg:
           - linux-modules-extra-gcp
       when: 
-        - system_uuid.stdout != "ec2*" or system_uuid.stdout != "EC2*"
+        - system_vendor.stdout != "Amazon EC2" or system_vendor.stdout != "Vultr"
 
     - name: Configure ulimit
       ansible.builtin.blockinfile:

--- a/roles/common/tasks/base.yml
+++ b/roles/common/tasks/base.yml
@@ -77,8 +77,8 @@
 
     - name: Grab uuid for extra kernel modules
       ansible.builtin.shell: |
-        dmidecode --string system-uuid
-      register: system_uuid
+        dmidecode --string bios-vendor
+      register: system_vendor
       ignore_errors: true
 
     - name: Ensure extra AWS modules are installed
@@ -86,7 +86,7 @@
         pkg:
           - linux-modules-extra-aws
       when:
-        - system_uuid.stdout == "ec2*" or system_uuid.stdout == "EC2*"
+        - system_vendor.stdout == "Amazon EC2" or system_vendor.stdout == "Vultr"
 
     # linux-modules-extra-gcp is not published for Ubuntu 26.04; ignore failure on that release.
     - name: Ensure extra GCP modules are installed
@@ -95,7 +95,7 @@
           - linux-modules-extra-gcp
       ignore_errors: true
       when:
-        - system_uuid.stdout != "ec2*" or system_uuid.stdout != "EC2*"
+        - system_vendor.stdout != "Amazon EC2" or system_vendor.stdout != "Vultr"
 
     - name: Configure ulimit
       ansible.builtin.blockinfile:


### PR DESCRIPTION
use BIOS vendor instead of system UUID for AWS and GCP compatibility, include AWS and Vultr in the logic.