### PR TITLE
Ignore missing linux-modules-extra-aws on Ubuntu 26.04

### DIFF
--- a/roles/common/tasks/base.yml
+++ b/roles/common/tasks/base.yml
@@ -81,10 +81,12 @@
       register: system_vendor
       ignore_errors: true
 
+    # linux-modules-extra-aws is not published for Ubuntu 26.04; ignore failure on that release.
     - name: Ensure extra AWS modules are installed
       ansible.builtin.apt:
         pkg:
           - linux-modules-extra-aws
+      ignore_errors: true
       when:
         - system_vendor.stdout == "Amazon EC2" or system_vendor.stdout == "Vultr"
 


### PR DESCRIPTION
The `linux-modules-extra-aws` package is not published in Ubuntu 26.04 repos. The AWS base image already ships with the necessary AWS hardware drivers (ENA, NVMe), so this package is not needed there.

Adding `ignore_errors: true` mirrors the existing handling on the GCP task (PR #267) so AWS Resolute builds stop failing.